### PR TITLE
Added --header CLI args support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ All the most popular MCP clients (Claude Desktop, Cursor & Windsurf) use the fol
 }
 ```
 
+### Custom Headers
+
+To bypass authentication, or to emit custom headers on all requests to your remote server, pass `--header` CLI arguments:
+
+```json
+{
+  "mcpServers": {
+    "remote-example": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--header",
+        "Authorization: Bearer ${AUTH_TOKEN}"
+      ]
+    },
+    "env": {
+      "AUTH_TOKEN": "..."
+    }
+  }
+}
+```
+
 ### Flags
 
 * If `npx` is producing errors, consider adding `-y` as the first argument to auto-accept the installation of the `mcp-remote` package.

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "mcp-remote-client": "dist/client.js"
   },
   "scripts": {
-    "dev": "tsup --watch",
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "check": "prettier --check . && tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-remote",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Remote proxy for Model Context Protocol, allowing local-only clients to connect to remote servers using oAuth",
   "keywords": [
     "mcp",

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,7 @@ import { coordinateAuth } from './lib/coordination'
 /**
  * Main function to run the client
  */
-async function runClient(serverUrl: string, callbackPort: number, clean: boolean = false) {
+async function runClient(serverUrl: string, callbackPort: number, headers: Record<string, string>, clean: boolean = false) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
@@ -64,7 +64,7 @@ async function runClient(serverUrl: string, callbackPort: number, clean: boolean
   // Create the transport factory
   const url = new URL(serverUrl)
   function initTransport() {
-    const transport = new SSEClientTransport(url, { authProvider })
+    const transport = new SSEClientTransport(url, { authProvider, requestInit: { headers } })
 
     // Set up message and error handlers
     transport.onmessage = (message) => {
@@ -160,8 +160,8 @@ async function runClient(serverUrl: string, callbackPort: number, clean: boolean
 
 // Parse command-line arguments and run the client
 parseCommandLineArgs(process.argv.slice(2), 3333, 'Usage: npx tsx client.ts [--clean] <https://server-url> [callback-port]')
-  .then(({ serverUrl, callbackPort, clean }) => {
-    return runClient(serverUrl, callbackPort, clean)
+  .then(({ serverUrl, callbackPort, clean, headers }) => {
+    return runClient(serverUrl, callbackPort, headers, clean)
   })
   .catch((error) => {
     console.error('Fatal error:', error)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,7 +21,7 @@ import { coordinateAuth } from './lib/coordination'
 /**
  * Main function to run the proxy
  */
-async function runProxy(serverUrl: string, callbackPort: number, clean: boolean = false) {
+async function runProxy(serverUrl: string, callbackPort: number, headers: Record<string, string>, clean: boolean = false) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
@@ -52,7 +52,7 @@ async function runProxy(serverUrl: string, callbackPort: number, clean: boolean 
 
   try {
     // Connect to remote server with authentication
-    const remoteTransport = await connectToRemoteServer(serverUrl, authProvider, waitForAuthCode, skipBrowserAuth)
+    const remoteTransport = await connectToRemoteServer(serverUrl, authProvider, headers, waitForAuthCode, skipBrowserAuth)
 
     // Set up bidirectional proxy between local and remote transports
     mcpProxy({
@@ -104,8 +104,8 @@ to the CA certificate file. If using claude_desktop_config.json, this might look
 
 // Parse command-line arguments and run the proxy
 parseCommandLineArgs(process.argv.slice(2), 3334, 'Usage: npx tsx proxy.ts [--clean] <https://server-url> [callback-port]')
-  .then(({ serverUrl, callbackPort, clean }) => {
-    return runProxy(serverUrl, callbackPort, clean)
+  .then(({ serverUrl, callbackPort, clean, headers }) => {
+    return runProxy(serverUrl, callbackPort, headers, clean)
   })
   .catch((error) => {
     log('Fatal error:', error)


### PR DESCRIPTION
This can include ${ENV_VAR} strings that are replaced with the values in process.env:

```json
{
  "mcpServers": {
    "remote-example": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://remote.mcp.server/sse",
        "--header",
        "Authorization: Bearer ${AUTH_TOKEN}"
      ]
    },
    "env": {
      "AUTH_TOKEN": "..."
    }
  }
}
```

It doesn't actually change any of the _logic_ inside `mcp-remote`, but if you construct a valid Bearer token your server should never return a 401 and should skip all the auth logic.
