### PR TITLE
PR: Fix Authorization Header for SSE Connections

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,16 +26,12 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
   transportToClient.onmessage = (message) => {
     // @ts-expect-error TODO
     log('[Local→Remote]', message.method || message.id)
-    // Log full outgoing request details
-    log('[Local→Remote Full]', JSON.stringify(message, null, 2))
     transportToServer.send(message).catch(onServerError)
   }
 
   transportToServer.onmessage = (message) => {
     // @ts-expect-error TODO: fix this type
     log('[Remote→Local]', message.method || message.id)
-    // Log full response details
-    log('[Remote→Local Full]', JSON.stringify(message, null, 2))
     transportToClient.send(message).catch(onClientError)
   }
 


### PR DESCRIPTION
## Issue
When using Bearer token authentication with the MCP proxy, the token was correctly being sent in regular HTTP requests but was being omitted from the Server-Sent Events (SSE) connection. This resulted in 401 Unauthorized errors when connecting to SSE endpoints that require authentication.

## Root Cause
The SSE connection is established using the browser's native EventSource API, which doesn't automatically include custom headers from the requestInit object. While the Authorization header was correctly being set for regular HTTP requests, it wasn't being passed to the EventSource connection.

## Solution
Added a custom EventSource initialization that explicitly passes the Authorization header to the SSE connection. This is done by providing an eventSourceInit object with a custom fetch function that ensures all headers (including the Authorization header) are correctly included in every request.

```
const eventSourceInit = {
  fetch: (url: string | URL, init: RequestInit | undefined) => {
    return fetch(url, {
      ...init,
      headers: {
        ...init?.headers,
        ...headers,  // This ensures Authorization header is included
      },
    })
  },
}
```

## Minimal Changes
The fix is minimal and straightforward - it doesn't change any existing behavior but simply ensures that when headers are provided (particularly Authorization headers), they are properly forwarded to the SSE connection. It's a focused solution that addresses only the specific issue without introducing broader architectural changes.

## Testing
Tested with a CloudFront Lambda SSE endpoint that requires Bearer token authentication. The logs confirmed that:

Before the fix: SSE requests were reporting "No Authorization header found"
After the fix: SSE requests successfully include the Authorization header and authenticate properly

