### PR TITLE
Add software_id/software_version

### DIFF
--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -9,7 +9,7 @@ import {
 } from '@modelcontextprotocol/sdk/shared/auth.js'
 import type { OAuthProviderOptions } from './types'
 import { readJsonFile, writeJsonFile, readTextFile, writeTextFile } from './mcp-auth-config'
-import { getServerUrlHash, log } from './utils'
+import { getServerUrlHash, log, MCP_REMOTE_VERSION } from './utils'
 
 /**
  * Implements the OAuthClientProvider interface for Node.js environments.
@@ -20,6 +20,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private callbackPath: string
   private clientName: string
   private clientUri: string
+  private softwareId: string
+  private softwareVersion: string
 
   /**
    * Creates a new NodeOAuthClientProvider
@@ -30,6 +32,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.callbackPath = options.callbackPath || '/oauth/callback'
     this.clientName = options.clientName || 'MCP CLI Client'
     this.clientUri = options.clientUri || 'https://github.com/modelcontextprotocol/mcp-cli'
+    this.softwareId = options.softwareId || '2e6dc280-f3c3-4e01-99a7-8181dbd1d23d'
+    this.softwareVersion = options.softwareVersion || MCP_REMOTE_VERSION
   }
 
   get redirectUrl(): string {
@@ -44,6 +48,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       response_types: ['code'],
       client_name: this.clientName,
       client_uri: this.clientUri,
+      software_id: this.softwareId,
+      software_version: this.softwareVersion,
     }
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,10 @@ export interface OAuthProviderOptions {
   clientName?: string
   /** Client URI to use for OAuth registration */
   clientUri?: string
+  /** Software ID to use for OAuth registration */
+  softwareId?: string
+  /** Software version to use for OAuth registration */
+  softwareVersion?: string
 }
 
 /**


### PR DESCRIPTION
The [RFC for dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591#section-2) defines a pair of fields which the OAuth client can use when it sends a registration request, to identify the software it is running: `software_id` and `software_version`.

They're described as follows:
> software_id
> 
> A unique identifier string (e.g., a Universally Unique Identifier
> (UUID)) assigned by the client developer or software publisher
> used by registration endpoints to identify the client software to
> be dynamically registered.  Unlike "client_id", which is issued by
> the authorization server and SHOULD vary between instances, the
> "software_id" SHOULD remain the same for all instances of the
> client software.  The "software_id" SHOULD remain the same across
> multiple updates or versions of the same piece of software.  The
> value of this field is not intended to be human readable and is
> usually opaque to the client and authorization server.


> software_version
> 
> A version identifier string for the client software identified by
> "software_id".  The value of the "software_version" SHOULD change
> on any update to the client software identified by the same
> "software_id".  The value of this field is intended to be compared
> using string equality matching and no other comparison semantics
> are defined by this specification.  The value of this field is
> outside the scope of this specification, but it is not intended to
> be human readable and is usually opaque to the client and
> authorization server.  The definition of what constitutes an
> update to client software that would trigger a change to this
> value is specific to the software itself and is outside the scope
> of this specification.

Sending these fields allows the Authorization Server to, for example, decide to return the same OAuth client ID for all registration requests from a given piece of software (see [RFC 7591 appendix A.4.2](https://datatracker.ietf.org/doc/html/rfc7591#appendix-A.4.2)).

This PR adds support for these two fields. The `software_id` is a random UUID v4 I just generated for use by mcp-remote, and the `software_version` uses `MCP_REMOTE_VERSION`.

Thank you!