### PR TITLE
feat(auth): Add dynamic client registration to connectToRemoteServer for proxy

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -85,16 +85,20 @@ export async function connectToRemoteServer(
 
   // Create transport with eventSourceInit to pass Authorization header if present
   const eventSourceInit = {
-    fetch: (url: string | URL, init: RequestInit | undefined) => {
-      return fetch(url, {
-        ...init,
-        headers: {
-          ...init?.headers,
-          ...headers,
-        },
-      })
+    fetch: (url: string | URL, init?: RequestInit) => {
+      return Promise.resolve(authProvider?.tokens?.()).then((tokens) =>
+        fetch(url, {
+          ...init,
+          headers: {
+            ...(init?.headers as Record<string, string> | undefined),
+            ...headers,
+            ...(tokens?.access_token ? { Authorization: `Bearer ${tokens.access_token}` } : {}),
+            Accept: "text/event-stream",
+          } as Record<string, string>,
+        })
+      );
     },
-  }
+  };
 
   const transport = new SSEClientTransport(url, {
     authProvider,


### PR DESCRIPTION
This commit adds dynamic OAuth client registration capability to the proxy.ts implementation, bringing it in line with the client.ts functionality. The proxy can now successfully connect to MCP servers that require dynamic client registration. The changes include:

- Adding client registration check and flow to connectToRemoteServer
- Safely handling optional saveClientInformation method 
- Proper error handling for auth providers that don't support registration
- Consistent logging throughout the registration process

Previously, the proxy would fail to connect to servers requiring dynamic registration, while the client worked fine. This change ensures both components have the same capabilities for OAuth authentication.