### PR TITLE
add --allow-http flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ To bypass authentication, or to emit custom headers on all requests to your remo
       ]
 ```
 
+* To allow HTTP connections in trusted private networks, add the `--allow-http` flag. Note: This should only be used in secure private networks where traffic cannot be intercepted.
+
+```json
+      "args": [
+        "mcp-remote",
+        "http://internal-service.vpc/sse",
+        "--allow-http"
+      ]
+```
+
 ### Claude Desktop
 
 [Official Docs](https://modelcontextprotocol.io/quickstart/user)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -299,6 +299,7 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
 
   const serverUrl = args[0]
   const specifiedPort = args[1] ? parseInt(args[1]) : undefined
+  const allowHttp = args.includes('--allow-http')
 
   if (!serverUrl) {
     log(usage)
@@ -308,7 +309,8 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
   const url = new URL(serverUrl)
   const isLocalhost = (url.hostname === 'localhost' || url.hostname === '127.0.0.1') && url.protocol === 'http:'
 
-  if (!(url.protocol == 'https:' || isLocalhost)) {
+  if (!(url.protocol == 'https:' || isLocalhost || allowHttp)) {
+    log('Error: Non-HTTPS URLs are only allowed for localhost or when --allow-http flag is provided')
     log(usage)
     process.exit(1)
   }


### PR DESCRIPTION
# Add --allow-http flag for private network usage

## Overview
This PR adds a `--allow-http` flag to allow HTTP connections in trusted private networks such as AWS VPC. Currently, the client enforces HTTPS except for localhost connections, but there are valid use cases where HTTPS is unnecessary or impractical within secure private networks.

## Changes
- Added `--allow-http` flag to bypass HTTPS requirement
- Updated error message to be more descriptive about when HTTP is allowed
- Maintained existing localhost exception while adding the new flag option

## Use Case
In private network environments like AWS VPC, where network traffic is already secured by infrastructure-level controls, requiring HTTPS can add unnecessary complexity. Some specific scenarios include:
- Internal services running within VPC that communicate only through private networks
- Development/testing environments in isolated networks

## Security Considerations
The `--allow-http` flag should only be used in environments where:
- Network traffic is contained within a secure private network (e.g., AWS VPC)
- Infrastructure-level security controls are in place
- Traffic cannot be intercepted by external parties

## Example Usage
```json
      "args": [
        "mcp-remote",
        "http://internal-service.vpc/sse",
        "--allow-http"
      ]
```