### PR TITLE
add --skip-auth flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ To bypass authentication, or to emit custom headers on all requests to your remo
       ]
 ```
 
+* To completely skip authentication for servers that don't require it, add the `--skip-auth` flag. While the primary purpose of mcp-remote is to provide OAuth authentication to clients connecting to MCP servers, this flag enables the tool to be used as a simple SSE connection proxy in trusted environments (e.g., development environments, internal networks) where authentication is not required.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--skip-auth"
+      ]
+```
+
 ### Claude Desktop
 
 [Official Docs](https://modelcontextprotocol.io/quickstart/user)

--- a/src/client.ts
+++ b/src/client.ts
@@ -156,7 +156,7 @@ async function runClient(serverUrl: string, callbackPort: number, headers: Recor
 
 // Parse command-line arguments and run the client
 parseCommandLineArgs(process.argv.slice(2), 3333, 'Usage: npx tsx client.ts <https://server-url> [callback-port]')
-  .then(({ serverUrl, callbackPort, headers }) => {
+  .then(({ serverUrl, callbackPort, headers, skipAuth }) => {
     return runClient(serverUrl, callbackPort, headers)
   })
   .catch((error) => {


### PR DESCRIPTION
# Add --skip-auth flag for trusted environments

## Background
While mcp-remote's primary purpose is to provide OAuth authentication capabilities to clients connecting to MCP servers (enabling stdio-only MCP clients to connect to remote authenticated servers), there are valid use cases where the tool can be beneficial even without authentication, particularly in trusted environments.

## Changes
This PR introduces the `--skip-auth` flag which allows mcp-remote to operate as a simple SSE connection proxy, bypassing all authentication-related processes. This addition:

- Enables usage in development environments where authentication is not required
- Simplifies setup in trusted networks
- Reduces overhead when working with non-authenticated MCP servers

## Use Case
The original purpose of mcp-remote is to bridge the gap between stdio-only MCP clients and remote authenticated servers by providing OAuth capabilities. However, there are several scenarios where direct SSE connection capabilities are valuable:

1. **Cloud Desktop Environment Support**: Currently, Cloud Desktop does not support remote connections natively. In development environments where Cloud Desktop is used with local MCP servers, mcp-remote can serve as a simple SSE connection proxy without the need for authentication overhead.

2. **Development Environments**: In local development setups or internal networks where authentication is not required, the authentication layer becomes unnecessary overhead.

3. **Testing and Debugging**: When testing MCP server implementations or debugging connection issues, having a simple SSE proxy without authentication complexity can be beneficial.

The `--skip-auth` flag allows developers to utilize mcp-remote's SSE connection proxy capabilities directly in these trusted environments, making it particularly valuable for Cloud Desktop users who need remote connection functionality.

## Implementation
The implementation is minimally invasive and maintains the existing authentication flow as the default behavior. The `--skip-auth` flag simply bypasses the authentication-related processes when specified, allowing the tool to function as a straightforward SSE connection proxy.

## Documentation
Updated README.md to clarify:
1. The tool's primary role in enabling stdio-only MCP clients to connect to remote authenticated servers
2. The intended use case for the `--skip-auth` flag in trusted environments where authentication is not needed
3. How this flag enables Cloud Desktop users to establish remote connections in development environments
4. How this flag allows the tool to be used as a simple SSE connection proxy while maintaining its core authentication bridging capabilities