### PR TITLE
Attempt to auto close web browser tab

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -208,7 +208,8 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     log('Auth code received, resolving promise')
     authCompletedResolve(code)
 
-    res.send('Authorization successful! You may close this window and return to the CLI.')
+    res.send('Authorization successful! You may close this window and return to the CLI.' +
+             '<script>window.close();</script>')
 
     // Notify main flow that auth code is available
     options.events.emit('auth-code-received', code)


### PR DESCRIPTION
In the event that the OAuth flow completes without user interaction (just one or more redirects, perhaps because the user was already cookied, was not prompted to provide further info or consent, etc.), we can use `window.close()` to close the browser tab automatically.