### PR TITLE
Fix: Support multiple --header arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .mcp-cli
 dist
+package-lock.json

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,10 @@
 import { OAuthClientProvider, UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { OAuthCallbackServerOptions } from './types'
+import crypto from 'crypto'
 import express from 'express'
 import net from 'net'
-import crypto from 'crypto'
+import { OAuthCallbackServerOptions } from './types'
 
 // Package version from package.json
 export const MCP_REMOTE_VERSION = require('../../package.json').version
@@ -293,7 +293,6 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
       } else {
         log(`Warning: ignoring invalid header argument: ${value}`)
       }
-      args.splice(i, 2)
     }
   })
 


### PR DESCRIPTION
### Fix: Support multiple --header arguments
Fixes [Cannot pass multiple --header arguments — only the first one is used #38](https://github.com/geelen/mcp-remote/issues/38)

### Changes
* Remove args.splice when parsing --header arguments.
* Allow accumulating multiple --header arguments into the headers object.

### Testing
Steps to verify:

1. Run the following command:
```

./dist/client.js http://127.0.0.1:8090/sse --header "http-header-1: xxx" --header "http-header-2: yyy" --allow-http
```

2. Confirm the output includes both headers, e.g.:
```
[86313] Using automatically selected callback port: 3333
[86313] Using custom headers: {"http-header-1":" xxx","http-header-2":" yyy"}
[86313] Connected successfully!
...
[86313] Listening for messages. Press Ctrl+C to exit.

```
### Notes
* This fixes the problem where only the first --header was recognized.
* The code now correctly parses and stores multiple headers as expected.