### PR TITLE
fix: Allow multiple --header arguments

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -130,14 +130,14 @@ export async function connectToRemoteServer(
   const sseTransport = transportStrategy === 'sse-only' || transportStrategy === 'sse-first'
   const transport = sseTransport
     ? new SSEClientTransport(url, {
-        authProvider,
-        requestInit: { headers },
-        eventSourceInit,
-      })
+      authProvider,
+      requestInit: { headers },
+      eventSourceInit,
+    })
     : new StreamableHTTPClientTransport(url, {
-        authProvider,
-        requestInit: { headers },
-      })
+      authProvider,
+      requestInit: { headers },
+    })
 
   try {
     if (client) {
@@ -376,8 +376,9 @@ export async function findAvailablePort(preferredPort?: number): Promise<number>
 export async function parseCommandLineArgs(args: string[], defaultPort: number, usage: string) {
   // Process headers
   const headers: Record<string, string> = {}
-  args.forEach((arg, i) => {
-    if (arg === '--header' && i < args.length - 1) {
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--header' && i < args.length - 1) {
       const value = args[i + 1]
       const match = value.match(/^([A-Za-z0-9_-]+):(.*)$/)
       if (match) {
@@ -386,8 +387,11 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
         log(`Warning: ignoring invalid header argument: ${value}`)
       }
       args.splice(i, 2)
+      // Do not increment i, as the array has shifted
+      continue
     }
-  })
+    i++
+  }
 
   const serverUrl = args[0]
   const specifiedPort = args[1] ? parseInt(args[1]) : undefined


### PR DESCRIPTION
Based on @geelen 's comment here https://github.com/geelen/mcp-remote/pull/41#issuecomment-2834778146, the bug in parseCommandLineArgs was caused by mutating the args array while iterating with forEach, which resulted in skipping some --header arguments. This has been fixed by switching to a while loop that only increments the index when no splicing occurs, ensuring all --header arguments are recognized and parsed. Verbose logging for each parsed header has also been added.

Fixes: https://github.com/geelen/mcp-remote/issues/38 and address https://github.com/geelen/mcp-remote/pull/41

### How to test

1. Run `node ./dist/proxy.js http://127.0.0.1:8090/sse --header "http-header-1: xxx" --header "http-header-2: yyy" --allow-http` in your terminal
2. Assert that you can see the following in your terminal
```
[23340] Parsed header: 'http-header-1' = ' xxx'
[23340] Parsed header: 'http-header-2' = ' yyy'
[23340] Using automatically selected callback port: 3334
[23340] Using custom headers: {"http-header-1":" xxx","http-header-2":" yyy"}
[23340] [23340] Connecting to remote server: http://127.0.0.1:8090/sse
[23340] Using transport strategy: http-first
```