### PR TITLE
Publishing all commits to pkg.pr.new

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Any Commit
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "!**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - run: pnpm dlx pkg-pr-new publish --compact --bin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-remote",
   "version": "0.1.2",
+  "packageManager": "pnpm@8.15.1",
   "description": "Remote proxy for Model Context Protocol, allowing local-only clients to connect to remote servers using oAuth",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Hopefully this means that anyone raising a PR gets an `npx https://pkg.pr.new/mcp-remote@<sha>` command they can use to test their versions out (and so can I, when reviewing 🥺 )