### PR TITLE
fix issue #64

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -477,6 +477,11 @@ export function setupSignalHandlers(cleanup: () => Promise<void>) {
 
   // Keep the process alive
   process.stdin.resume()
+  process.stdin.on('end', async () => {
+    log('\nShutting down...')
+    await cleanup()
+    process.exit(0)
+  })
 }
 
 /**


### PR DESCRIPTION
Every time Claude Desktop exits, mcp-remote process stay running as an orphan process.