### PR TITLE
Use existing client callbackPort as port sourcing strategy

### DIFF
--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -1,9 +1,8 @@
 import open from 'open'
 import { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import {
-  OAuthClientInformation,
   OAuthClientInformationFull,
-  OAuthClientInformationSchema,
+  OAuthClientInformationFullSchema,
   OAuthTokens,
   OAuthTokensSchema,
 } from '@modelcontextprotocol/sdk/shared/auth.js'
@@ -57,9 +56,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * Gets the client information if it exists
    * @returns The client information or undefined
    */
-  async clientInformation(): Promise<OAuthClientInformation | undefined> {
+  async clientInformation(): Promise<OAuthClientInformationFull | undefined> {
     // log('Reading client info')
-    return readJsonFile<OAuthClientInformation>(this.serverUrlHash, 'client_info.json', OAuthClientInformationSchema)
+    return readJsonFile<OAuthClientInformationFull>(this.serverUrlHash, 'client_info.json', OAuthClientInformationFullSchema)
   }
 
   /**


### PR DESCRIPTION
Fixes #72

@geelen I still have a doubt wether it would be preferred to use `specifiedPort` if specified rather than existing client port. WDYT ?