### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ To bypass authentication, or to emit custom headers on all requests to your remo
         "https://remote.mcp.server/sse",
         "--header",
         "Authorization: Bearer ${AUTH_TOKEN}"
-      ]
+      ],
+      "env": {
+        "AUTH_TOKEN": "..."
+      }
     },
-    "env": {
-      "AUTH_TOKEN": "..."
-    }
   }
 }
 ```
@@ -65,11 +65,11 @@ To bypass authentication, or to emit custom headers on all requests to your remo
     "https://remote.mcp.server/sse",
     "--header",
     "Authorization:${AUTH_HEADER}" // note no spaces around ':'
-  ]
+  ],
+  "env": {
+    "AUTH_HEADER": "Bearer <auth-token>" // spaces OK in env vars
+  }
 },
-"env": {
-  "AUTH_HEADER": "Bearer <auth-token>" // spaces OK in env vars
-}
 ```
 
 ### Flags


### PR DESCRIPTION
The current example has `env` placed incorrectly (at least for Cursor): 
```json
{
  "mcpServers": {
    "remote-example": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://remote.mcp.server/sse",
        "--header",
        "Authorization: Bearer ${AUTH_TOKEN}"
      ]
    },
    "env": {
      "AUTH_TOKEN": "..."
    }
  }
}

```

This just moves the `"env"` into the `"remote-example"` configuration. If you don't pay attention, you'll end up wondering why you have empty `env` being passed through.