### PR TITLE
[AMP] Simplify debug log calls by removing hash

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,7 +44,7 @@ async function runClient(
   const serverUrlHash = getServerUrlHash(serverUrl)
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events)
+  const authCoordinator = createLazyAuthCoordinator(callbackPort, events)
 
   // Create the OAuth client provider
   const authProvider = new NodeOAuthClientProvider({

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -17,10 +17,10 @@ export type AuthCoordinator = {
 export async function isPidRunning(pid: number): Promise<boolean> {
   try {
     process.kill(pid, 0) // Doesn't kill the process, just checks if it exists
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, `Process ${pid} is running`)
+    if (DEBUG) await debugLog(`Process ${pid} is running`)
     return true
   } catch (err) {
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, `Process ${pid} is not running`, err)
+    if (DEBUG) await debugLog(`Process ${pid} is not running`, err)
     return false
   }
 }
@@ -31,13 +31,13 @@ export async function isPidRunning(pid: number): Promise<boolean> {
  * @returns True if the lockfile is valid, false otherwise
  */
 export async function isLockValid(lockData: LockfileData): Promise<boolean> {
-  if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Checking if lockfile is valid', lockData)
+  if (DEBUG) await debugLog('Checking if lockfile is valid', lockData)
   
   // Check if the lockfile is too old (over 30 minutes)
   const MAX_LOCK_AGE = 30 * 60 * 1000 // 30 minutes
   if (Date.now() - lockData.timestamp > MAX_LOCK_AGE) {
     log('Lockfile is too old')
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Lockfile is too old', {
+    if (DEBUG) await debugLog('Lockfile is too old', {
       age: Date.now() - lockData.timestamp,
       maxAge: MAX_LOCK_AGE
     })
@@ -47,13 +47,13 @@ export async function isLockValid(lockData: LockfileData): Promise<boolean> {
   // Check if the process is still running
   if (!(await isPidRunning(lockData.pid))) {
     log('Process from lockfile is not running')
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Process from lockfile is not running', { pid: lockData.pid })
+    if (DEBUG) await debugLog('Process from lockfile is not running', { pid: lockData.pid })
     return false
   }
 
   // Check if the endpoint is accessible
   try {
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Checking if endpoint is accessible', { port: lockData.port })
+    if (DEBUG) await debugLog('Checking if endpoint is accessible', { port: lockData.port })
     
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 1000)
@@ -65,11 +65,11 @@ export async function isLockValid(lockData: LockfileData): Promise<boolean> {
     clearTimeout(timeout)
     
     const isValid = response.status === 200 || response.status === 202
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, `Endpoint check result: ${isValid ? 'valid' : 'invalid'}`, { status: response.status })
+    if (DEBUG) await debugLog(`Endpoint check result: ${isValid ? 'valid' : 'invalid'}`, { status: response.status })
     return isValid
   } catch (error) {
     log(`Error connecting to auth server: ${(error as Error).message}`)
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Error connecting to auth server', error)
+    if (DEBUG) await debugLog('Error connecting to auth server', error)
     return false
   }
 }
@@ -81,7 +81,7 @@ export async function isLockValid(lockData: LockfileData): Promise<boolean> {
  */
 export async function waitForAuthentication(port: number): Promise<boolean> {
   log(`Waiting for authentication from the server on port ${port}...`)
-  if (DEBUG) await debugLog(global.currentServerUrlHash!, `Waiting for authentication from server on port ${port}`)
+  if (DEBUG) await debugLog(`Waiting for authentication from server on port ${port}`)
 
   try {
     let attempts = 0;
@@ -89,49 +89,47 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
       attempts++;
       const url = `http://127.0.0.1:${port}/wait-for-auth`
       log(`Querying: ${url}`)
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, `Poll attempt ${attempts}: ${url}`)
+      if (DEBUG) await debugLog(`Poll attempt ${attempts}: ${url}`)
       
       try {
         const response = await fetch(url)
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, `Poll response status: ${response.status}`)
+        if (DEBUG) await debugLog(`Poll response status: ${response.status}`)
 
         if (response.status === 200) {
           // Auth completed, but we don't return the code anymore
           log(`Authentication completed by other instance`)
-          if (DEBUG) await debugLog(global.currentServerUrlHash!, `Authentication completed by other instance`)
+          if (DEBUG) await debugLog(`Authentication completed by other instance`)
           return true
         } else if (response.status === 202) {
           // Continue polling
           log(`Authentication still in progress`)
-          if (DEBUG) await debugLog(global.currentServerUrlHash!, `Authentication still in progress, will retry in 1s`)
+          if (DEBUG) await debugLog(`Authentication still in progress, will retry in 1s`)
           await new Promise((resolve) => setTimeout(resolve, 1000))
         } else {
           log(`Unexpected response status: ${response.status}`)
-          if (DEBUG) await debugLog(global.currentServerUrlHash!, `Unexpected response status`, { status: response.status })
+          if (DEBUG) await debugLog(`Unexpected response status`, { status: response.status })
           return false
         }
       } catch (fetchError) {
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, `Fetch error during poll`, fetchError)
+        if (DEBUG) await debugLog(`Fetch error during poll`, fetchError)
         // If we can't connect, we'll try again after a delay
         await new Promise((resolve) => setTimeout(resolve, 2000))
       }
     }
   } catch (error) {
     log(`Error waiting for authentication: ${(error as Error).message}`)
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, `Error waiting for authentication`, error)
+    if (DEBUG) await debugLog(`Error waiting for authentication`, error)
     return false
   }
 }
 
 /**
  * Creates a lazy auth coordinator that will only initiate auth when needed
- * @param serverUrlHash The hash of the server URL
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
  * @returns An AuthCoordinator object with an initializeAuth method
  */
 export function createLazyAuthCoordinator(
-  serverUrlHash: string,
   callbackPort: number,
   events: EventEmitter
 ): AuthCoordinator {
@@ -141,16 +139,16 @@ export function createLazyAuthCoordinator(
     initializeAuth: async () => {
       // If auth has already been initialized, return the existing state
       if (authState) {
-        if (DEBUG) await debugLog(serverUrlHash, 'Auth already initialized, reusing existing state')
+        if (DEBUG) await debugLog('Auth already initialized, reusing existing state')
         return authState
       }
 
       log('Initializing auth coordination on-demand')
-      if (DEBUG) await debugLog(serverUrlHash, 'Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
+      if (DEBUG) await debugLog('Initializing auth coordination on-demand', { callbackPort })
       
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events)
-      if (DEBUG) await debugLog(serverUrlHash, 'Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
+      authState = await coordinateAuth(global.currentServerUrlHash!, callbackPort, events)
+      if (DEBUG) await debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
       return authState
     }
   }
@@ -158,52 +156,52 @@ export function createLazyAuthCoordinator(
 
 /**
  * Coordinates authentication between multiple instances of the client/proxy
- * @param serverUrlHash The hash of the server URL
+ * @param serverUrlHash The hash of the server URL (will use global.currentServerUrlHash in the future)
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
  * @returns An object with the server, waitForAuthCode function, and a flag indicating if browser auth can be skipped
  */
 export async function coordinateAuth(
-  serverUrlHash: string,
+  serverUrlHash: string, // Use global value where possible, parameter kept for backward compatibility
   callbackPort: number,
   events: EventEmitter,
 ): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
-  if (DEBUG) await debugLog(serverUrlHash, 'Coordinating authentication', { serverUrlHash, callbackPort })
+  if (DEBUG) await debugLog('Coordinating authentication', { callbackPort })
   
   // Check for a lockfile (disabled on Windows for the time being)
   const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
   
   if (DEBUG) {
     if (process.platform === 'win32') {
-      await debugLog(serverUrlHash, 'Skipping lockfile check on Windows')
+      await debugLog('Skipping lockfile check on Windows')
     } else {
-      await debugLog(serverUrlHash, 'Lockfile check result', { found: !!lockData, lockData })
+      await debugLog('Lockfile check result', { found: !!lockData, lockData })
     }
   }
 
   // If there's a valid lockfile, try to use the existing auth process
   if (lockData && (await isLockValid(lockData))) {
     log(`Another instance is handling authentication on port ${lockData.port}`)
-    if (DEBUG) await debugLog(serverUrlHash, 'Another instance is handling authentication', { port: lockData.port, pid: lockData.pid })
+    if (DEBUG) await debugLog('Another instance is handling authentication', { port: lockData.port, pid: lockData.pid })
 
     try {
       // Try to wait for the authentication to complete
-      if (DEBUG) await debugLog(serverUrlHash, 'Waiting for authentication from other instance')
+      if (DEBUG) await debugLog('Waiting for authentication from other instance')
       const authCompleted = await waitForAuthentication(lockData.port)
       
       if (authCompleted) {
         log('Authentication completed by another instance')
-        if (DEBUG) await debugLog(serverUrlHash, 'Authentication completed by another instance, will use tokens from disk')
+        if (DEBUG) await debugLog('Authentication completed by another instance, will use tokens from disk')
 
         // Setup a dummy server - the client will use tokens directly from disk
         const dummyServer = express().listen(0) // Listen on any available port
         const dummyPort = (dummyServer.address() as AddressInfo).port
-        if (DEBUG) await debugLog(serverUrlHash, 'Started dummy server', { port: dummyPort })
+        if (DEBUG) await debugLog('Started dummy server', { port: dummyPort })
 
         // This shouldn't actually be called in normal operation, but provide it for API compatibility
         const dummyWaitForAuthCode = () => {
           log('WARNING: waitForAuthCode called in secondary instance - this is unexpected')
-          if (DEBUG) debugLog(serverUrlHash, 'WARNING: waitForAuthCode called in secondary instance - this is unexpected').catch(() => {})
+          if (DEBUG) debugLog('WARNING: waitForAuthCode called in secondary instance - this is unexpected').catch(() => {})
           // Return a promise that never resolves - the client should use the tokens from disk instead
           return new Promise<string>(() => {})
         }
@@ -215,25 +213,25 @@ export async function coordinateAuth(
         }
       } else {
         log('Taking over authentication process...')
-        if (DEBUG) await debugLog(serverUrlHash, 'Taking over authentication process')
+        if (DEBUG) await debugLog('Taking over authentication process')
       }
     } catch (error) {
       log(`Error waiting for authentication: ${error}`)
-      if (DEBUG) await debugLog(serverUrlHash, 'Error waiting for authentication', error)
+      if (DEBUG) await debugLog('Error waiting for authentication', error)
     }
 
     // If we get here, the other process didn't complete auth successfully
-    if (DEBUG) await debugLog(serverUrlHash, 'Other instance did not complete auth successfully, deleting lockfile')
+    if (DEBUG) await debugLog('Other instance did not complete auth successfully, deleting lockfile')
     await deleteLockfile(serverUrlHash)
   } else if (lockData) {
     // Invalid lockfile, delete it
     log('Found invalid lockfile, deleting it')
-    if (DEBUG) await debugLog(serverUrlHash, 'Found invalid lockfile, deleting it')
+    if (DEBUG) await debugLog('Found invalid lockfile, deleting it')
     await deleteLockfile(serverUrlHash)
   }
 
   // Create our own lockfile
-  if (DEBUG) await debugLog(serverUrlHash, 'Setting up OAuth callback server', { port: callbackPort })
+  if (DEBUG) await debugLog('Setting up OAuth callback server', { port: callbackPort })
   const { server, waitForAuthCode, authCompletedPromise } = setupOAuthCallbackServerWithLongPoll({
     port: callbackPort,
     path: '/oauth/callback',
@@ -243,21 +241,21 @@ export async function coordinateAuth(
   // Get the actual port the server is running on
   const address = server.address() as AddressInfo
   const actualPort = address.port
-  if (DEBUG) await debugLog(serverUrlHash, 'OAuth callback server running', { port: actualPort })
+  if (DEBUG) await debugLog('OAuth callback server running', { port: actualPort })
 
   log(`Creating lockfile for server ${serverUrlHash} with process ${process.pid} on port ${actualPort}`)
-  if (DEBUG) await debugLog(serverUrlHash, 'Creating lockfile', { serverUrlHash, pid: process.pid, port: actualPort })
+  if (DEBUG) await debugLog('Creating lockfile', { pid: process.pid, port: actualPort })
   await createLockfile(serverUrlHash, process.pid, actualPort)
 
   // Make sure lockfile is deleted on process exit
   const cleanupHandler = async () => {
     try {
       log(`Cleaning up lockfile for server ${serverUrlHash}`)
-      if (DEBUG) await debugLog(serverUrlHash, 'Cleaning up lockfile')
+      if (DEBUG) await debugLog('Cleaning up lockfile')
       await deleteLockfile(serverUrlHash)
     } catch (error) {
       log(`Error cleaning up lockfile: ${error}`)
-      if (DEBUG) await debugLog(serverUrlHash, 'Error cleaning up lockfile', error)
+      if (DEBUG) await debugLog('Error cleaning up lockfile', error)
     }
   }
 
@@ -274,11 +272,11 @@ export async function coordinateAuth(
 
   // Also handle SIGINT separately
   process.once('SIGINT', async () => {
-    if (DEBUG) await debugLog(serverUrlHash, 'Received SIGINT signal, cleaning up')
+    if (DEBUG) await debugLog('Received SIGINT signal, cleaning up')
     await cleanupHandler()
   })
 
-  if (DEBUG) await debugLog(serverUrlHash, 'Auth coordination complete, returning primary instance handlers')
+  if (DEBUG) await debugLog('Auth coordination complete, returning primary instance handlers')
   return {
     server,
     waitForAuthCode,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,7 +39,9 @@ function getTimestamp(): string {
 }
 
 // Debug logging function
-export async function debugLog(serverUrlHash: string, message: string, ...args: any[]): Promise<void> {
+export async function debugLog(message: string, ...args: any[]): Promise<void> {
+  // Use the global server hash
+  const serverUrlHash = global.currentServerUrlHash!;
   if (!DEBUG) return;
 
   try {
@@ -72,7 +74,7 @@ export function log(str: string, ...rest: unknown[]) {
 
   // If debug mode is on, also log to debug file
   if (DEBUG && global.currentServerUrlHash) {
-    debugLog(global.currentServerUrlHash, str, ...rest).catch(() => {});
+    debugLog(str, ...rest).catch(() => {});
   }
 }
 
@@ -90,7 +92,7 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
     log('[Local→Remote]', message.method || message.id)
 
     if (DEBUG) {
-      debugLog(global.currentServerUrlHash!, 'Local → Remote message', {
+      debugLog('Local → Remote message', {
         method: message.method,
         id: message.id,
         params: message.params ? JSON.stringify(message.params).substring(0, 500) : undefined
@@ -103,7 +105,7 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
       log(JSON.stringify(message, null, 2))
 
       if (DEBUG) {
-        debugLog(global.currentServerUrlHash!, 'Initialize message with modified client info', { clientInfo }).catch(() => {})
+        debugLog('Initialize message with modified client info', { clientInfo }).catch(() => {})
       }
     }
 
@@ -116,7 +118,7 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
     log('[Remote→Local]', message.method || message.id)
 
     if (DEBUG) {
-      debugLog(global.currentServerUrlHash!, 'Remote → Local message', {
+      debugLog('Remote → Local message', {
         method: message.method,
         id: message.id,
         result: message.result ? 'result-present' : undefined,
@@ -133,7 +135,7 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
     }
 
     transportToClientClosed = true
-    if (DEBUG) debugLog(global.currentServerUrlHash!, 'Local transport closed, closing remote transport').catch(() => {})
+    if (DEBUG) debugLog('Local transport closed, closing remote transport').catch(() => {})
     transportToServer.close().catch(onServerError)
   }
 
@@ -142,7 +144,7 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
       return
     }
     transportToServerClosed = true
-    if (DEBUG) debugLog(global.currentServerUrlHash!, 'Remote transport closed, closing local transport').catch(() => {})
+    if (DEBUG) debugLog('Remote transport closed, closing local transport').catch(() => {})
     transportToClient.close().catch(onClientError)
   }
 
@@ -151,12 +153,12 @@ export function mcpProxy({ transportToClient, transportToServer }: { transportTo
 
   function onClientError(error: Error) {
     log('Error from local client:', error)
-    if (DEBUG) debugLog(global.currentServerUrlHash!, 'Error from local client', { errorMessage: error.message, stack: error.stack }).catch(() => {})
+    if (DEBUG) debugLog('Error from local client', { errorMessage: error.message, stack: error.stack }).catch(() => {})
   }
 
   function onServerError(error: Error) {
     log('Error from remote server:', error)
-    if (DEBUG) debugLog(global.currentServerUrlHash!, 'Error from remote server', { errorMessage: error.message, stack: error.stack }).catch(() => {})
+    if (DEBUG) debugLog('Error from remote server', { errorMessage: error.message, stack: error.stack }).catch(() => {})
   }
 }
 
@@ -227,27 +229,27 @@ export async function connectToRemoteServer(
       })
 
   try {
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Attempting to connect to remote server', { sseTransport })
+    if (DEBUG) await debugLog('Attempting to connect to remote server', { sseTransport })
 
     if (client) {
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Connecting client to transport')
+      if (DEBUG) await debugLog('Connecting client to transport')
       await client.connect(transport)
     } else {
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Starting transport directly')
+      if (DEBUG) await debugLog('Starting transport directly')
       await transport.start()
       if (!sseTransport) {
         // Extremely hacky, but we didn't actually send a request when calling transport.start() above, so we don't
         // know if we're even talking to an HTTP server. But if we forced that now we'd get an error later saying that
         // the client is already connected. So let's just create a one-off client to make a single request and figure
         // out if we're actually talking to an HTTP server or not.
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Creating test transport for HTTP-only connection test')
+        if (DEBUG) await debugLog('Creating test transport for HTTP-only connection test')
         const testTransport = new StreamableHTTPClientTransport(url, { authProvider, requestInit: { headers } })
         const testClient = new Client({ name: 'mcp-remote-fallback-test', version: '0.0.0' }, { capabilities: {} })
         await testClient.connect(testTransport)
       }
     }
     log(`Connected to remote server using ${transport.constructor.name}`)
-    if (DEBUG) await debugLog(global.currentServerUrlHash!, `Connected to remote server successfully`, { transportType: transport.constructor.name })
+    if (DEBUG) await debugLog(`Connected to remote server successfully`, { transportType: transport.constructor.name })
 
     return transport
   } catch (error) {
@@ -287,57 +289,57 @@ export async function connectToRemoteServer(
     } else if (error instanceof UnauthorizedError || (error instanceof Error && error.message.includes('Unauthorized'))) {
       log('Authentication required. Initializing auth...')
       if (DEBUG) {
-        await debugLog(global.currentServerUrlHash!, 'Authentication required, initializing auth process', {
+        await debugLog('Authentication required, initializing auth process', {
           errorMessage: error.message,
           stack: error.stack
         })
       }
 
       // Initialize authentication on-demand
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Calling authInitializer to start auth flow')
+      if (DEBUG) await debugLog('Calling authInitializer to start auth flow')
       const { waitForAuthCode, skipBrowserAuth } = await authInitializer()
 
       if (skipBrowserAuth) {
         log('Authentication required but skipping browser auth - using shared auth')
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Authentication required but skipping browser auth - using shared auth')
+        if (DEBUG) await debugLog('Authentication required but skipping browser auth - using shared auth')
       } else {
         log('Authentication required. Waiting for authorization...')
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Authentication required. Waiting for authorization...')
+        if (DEBUG) await debugLog('Authentication required. Waiting for authorization...')
       }
 
       // Wait for the authorization code from the callback
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Waiting for auth code from callback server')
+      if (DEBUG) await debugLog('Waiting for auth code from callback server')
       const code = await waitForAuthCode()
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Received auth code from callback server')
+      if (DEBUG) await debugLog('Received auth code from callback server')
 
       try {
         log('Completing authorization...')
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Completing authorization with transport.finishAuth')
+        if (DEBUG) await debugLog('Completing authorization with transport.finishAuth')
         await transport.finishAuth(code)
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Authorization completed successfully')
+        if (DEBUG) await debugLog('Authorization completed successfully')
 
         if (recursionReasons.has(REASON_AUTH_NEEDED)) {
           const errorMessage = `Already attempted reconnection for reason: ${REASON_AUTH_NEEDED}. Giving up.`
           log(errorMessage)
-          if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Already attempted auth reconnection, giving up', { recursionReasons: Array.from(recursionReasons) })
+          if (DEBUG) await debugLog('Already attempted auth reconnection, giving up', { recursionReasons: Array.from(recursionReasons) })
           throw new Error(errorMessage)
         }
 
         // Track this reason for recursion
         recursionReasons.add(REASON_AUTH_NEEDED)
         log(`Recursively reconnecting for reason: ${REASON_AUTH_NEEDED}`)
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Recursively reconnecting after auth', { recursionReasons: Array.from(recursionReasons) })
+        if (DEBUG) await debugLog('Recursively reconnecting after auth', { recursionReasons: Array.from(recursionReasons) })
 
         // Recursively call connectToRemoteServer with the updated recursion tracking
         return connectToRemoteServer(client, serverUrl, authProvider, headers, authInitializer, transportStrategy, recursionReasons)
       } catch (authError) {
         log('Authorization error:', authError)
-        if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Authorization error during finishAuth', { errorMessage: authError.message, stack: authError.stack })
+        if (DEBUG && authError instanceof Error) await debugLog('Authorization error during finishAuth', { errorMessage: authError.message, stack: authError.stack })
         throw authError
       }
     } else {
       log('Connection error:', error)
-      if (DEBUG) await debugLog(global.currentServerUrlHash!, 'Connection error', {
+      if (DEBUG && error instanceof Error) await debugLog('Connection error', {
         errorMessage: error.message,
         stack: error.stack,
         transportType: transport.constructor.name
@@ -617,7 +619,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   global.currentServerUrlHash = serverUrlHash
 
   if (DEBUG) {
-    debugLog(serverUrlHash, `Starting mcp-remote with server URL: ${serverUrl}`).catch(() => {})
+    debugLog(`Starting mcp-remote with server URL: ${serverUrl}`).catch(() => {})
   }
 
   const defaultPort = calculateDefaultPort(serverUrlHash)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,7 +44,7 @@ async function runProxy(
   const serverUrlHash = getServerUrlHash(serverUrl)
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events)
+  const authCoordinator = createLazyAuthCoordinator(callbackPort, events)
 
   // Create the OAuth client provider
   const authProvider = new NodeOAuthClientProvider({

--- a/update_debuglog.sh
+++ b/update_debuglog.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed -i '' 's/debugLog(global\.currentServerUrlHash!, /debugLog(/g' src/lib/coordination.ts
+sed -i '' 's/debugLog(serverUrlHash, /debugLog(/g' src/lib/coordination.ts


### PR DESCRIPTION
Prompt:

```
I added a debug flag recently, that needs the server hash to know 
where to write the debug logs. But I think I am already storing that 
hash in a global variable, except all the debug log calls still pass it 
in. Can you change it so the debug log calls don't specify the server 
hash anywhere?
```

Conversation here: https://ampcode.com/threads/T-7f675162-7b10-43c5-98a7-cff18ad07e9b

It took a long time, changed more than I asked it for, had to create a script to do more find-replaces, got that wrong then fixed it, then tried running `tsc` which actually found unrelated errors (sorry, Amp, bum steer there). But interesting, nonetheless.