### PR TITLE
Fix missing require method when running directly

### DIFF
--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
 import { AddressInfo } from 'net'
+import { unlinkSync } from 'fs'
 import { log, debugLog, DEBUG, setupOAuthCallbackServerWithLongPoll } from './utils'
 
 export type AuthCoordinator = {
@@ -263,7 +264,7 @@ export async function coordinateAuth(
     try {
       // Synchronous version for 'exit' event since we can't use async here
       const configPath = getConfigFilePath(serverUrlHash, 'lock.json')
-      require('fs').unlinkSync(configPath)
+      unlinkSync(configPath)
       if (DEBUG) console.error(`[DEBUG] Removed lockfile on exit: ${configPath}`)
     } catch (error) {
       if (DEBUG) console.error(`[DEBUG] Error removing lockfile on exit:`, error)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,8 +12,8 @@ import crypto from 'crypto'
 import fs, { readFile } from 'fs/promises'
 import path from 'path'
 import os from 'os'
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
 
 // Global type declaration for typescript
 declare global {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,8 @@ import crypto from 'crypto'
 import fs, { readFile } from 'fs/promises'
 import path from 'path'
 import os from 'os'
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 // Global type declaration for typescript
 declare global {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,7 +18,6 @@ import {
   parseCommandLineArgs,
   setupSignalHandlers,
   getServerUrlHash,
-  MCP_REMOTE_VERSION,
   TransportStrategy,
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'


### PR DESCRIPTION
Fixes #100

Now runs with:

```bash
$ npx tsx ./src/proxy.ts http://mcp-remote-server.com PORT
```

These commands completed successfully:

```bash
$ npm run check
$ npm run build
```