### PR TITLE
Add resource parameter to authorize URL

### DIFF
--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -172,7 +172,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     if (this.authorizeResource) {
       authorizationUrl.searchParams.set('resource', this.authorizeResource)
     }
-    
+
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 
     if (DEBUG) debugLog('Redirecting to authorization URL', authorizationUrl.toString())

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -25,6 +25,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private softwareVersion: string
   private staticOAuthClientMetadata: StaticOAuthClientMetadata
   private staticOAuthClientInfo: StaticOAuthClientInformationFull
+  private authorizeResource: string | undefined
   private _state: string
 
   /**
@@ -40,6 +41,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.softwareVersion = options.softwareVersion || MCP_REMOTE_VERSION
     this.staticOAuthClientMetadata = options.staticOAuthClientMetadata
     this.staticOAuthClientInfo = options.staticOAuthClientInfo
+    this.authorizeResource = options.authorizeResource
     this._state = randomUUID()
   }
 
@@ -167,6 +169,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * @param authorizationUrl The URL to redirect to
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (this.authorizeResource) {
+      authorizationUrl.searchParams.set('resource', this.authorizeResource)
+    }
+    
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 
     if (DEBUG) debugLog('Redirecting to authorization URL', authorizationUrl.toString())

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,8 @@ export interface OAuthProviderOptions {
   staticOAuthClientMetadata?: StaticOAuthClientMetadata
   /** Static OAuth client information to use instead of OAuth registration */
   staticOAuthClientInfo?: StaticOAuthClientInformationFull
+  /** Resource parameter to send to the authorization server */
+  authorizeResource?: string
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -613,8 +613,8 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   let authorizeResource = '' // Default
   const resourceIndex = args.indexOf('--resource')
   if (resourceIndex !== -1 && resourceIndex < args.length - 1) {
-    host = args[resourceIndex + 1]
-    log(`Using authorize resource: ${resourceIndex}`)
+    authorizeResource = args[resourceIndex + 1]
+    log(`Using authorize resource: ${authorizeResource}`)
   }
 
   if (!serverUrl) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -609,6 +609,14 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     }
   }
 
+  // Parse resource to authorize
+  let authorizeResource = '' // Default
+  const resourceIndex = args.indexOf('--resource')
+  if (resourceIndex !== -1 && resourceIndex < args.length - 1) {
+    host = args[resourceIndex + 1]
+    log(`Using authorize resource: ${resourceIndex}`)
+  }
+
   if (!serverUrl) {
     log(usage)
     process.exit(1)
@@ -673,7 +681,17 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     })
   }
 
-  return { serverUrl, callbackPort, headers, transportStrategy, host, debug, staticOAuthClientMetadata, staticOAuthClientInfo }
+  return {
+    serverUrl,
+    callbackPort,
+    headers,
+    transportStrategy,
+    host,
+    debug,
+    staticOAuthClientMetadata,
+    staticOAuthClientInfo,
+    authorizeResource,
+  }
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,6 +54,7 @@ async function runProxy(
     clientName: 'MCP CLI Proxy',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
+    authorizeResource,
   })
 
   // Create the STDIO transport for local connections

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,7 @@ async function runProxy(
   host: string,
   staticOAuthClientMetadata: StaticOAuthClientMetadata,
   staticOAuthClientInfo: StaticOAuthClientInformationFull,
+  authorizeResource: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
@@ -142,9 +143,30 @@ to the CA certificate file. If using claude_desktop_config.json, this might look
 
 // Parse command-line arguments and run the proxy
 parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]')
-  .then(({ serverUrl, callbackPort, headers, transportStrategy, host, debug, staticOAuthClientMetadata, staticOAuthClientInfo }) => {
-    return runProxy(serverUrl, callbackPort, headers, transportStrategy, host, staticOAuthClientMetadata, staticOAuthClientInfo)
-  })
+  .then(
+    ({
+      serverUrl,
+      callbackPort,
+      headers,
+      transportStrategy,
+      host,
+      debug,
+      staticOAuthClientMetadata,
+      staticOAuthClientInfo,
+      authorizeResource,
+    }) => {
+      return runProxy(
+        serverUrl,
+        callbackPort,
+        headers,
+        transportStrategy,
+        host,
+        staticOAuthClientMetadata,
+        staticOAuthClientInfo,
+        authorizeResource,
+      )
+    },
+  )
   .catch((error) => {
     log('Fatal error:', error)
     process.exit(1)


### PR DESCRIPTION
The latest version of the MCP specification calls for a `resource` parameter to designate a specific API in the access token being requested:

https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#resource-parameter-implementation

I tested this locally to make sure it works:

```bash
$ npx tsx --env-file '.env' ../mcp-remote/src/proxy.ts http://localhost:7777/mcp 7778 --debug --allow-http --resource 'http://localhost:7777/mcp' --static-oauth-client-info '{"client_id":"Fg30xQlvl41x4xpAeetXLi2KSulNll7t"}'

# ...

[2025-06-25T21:43:38.953Z][15147]
Please authorize this client by visiting:
https://dev-mkyfb1wwc8aey0a2.us.auth0.com/authorize?response_type=code&client_id=Fg30xQlvl41x4xpAeetXLi2KSulNll7t&code_challenge=v6VaUgcU4p-ogvawRwHRSYwu7Pj39UL-Ry_nO3qA634&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A7778%2Foauth%2Fcallback&state=be9edf0e-93fe-453d-9e4d-9f8356f61fee&resource=https%3A%2F%2Flocalhost%3A7777%2Fmcp
```

Implementation is fairly simple but I added a note below.

Closes #109 