### PR TITLE
Updating to SDK 1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "strict-url-sanitise": "^0.0.1"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508",
+    "@modelcontextprotocol/sdk": "https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.10",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 0.0.1
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508
-        version: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508
+        specifier: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf
+        version: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -217,9 +217,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@modelcontextprotocol/sdk@https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508':
-    resolution: {tarball: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508}
-    version: 1.12.2
+  '@modelcontextprotocol/sdk@https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf':
+    resolution: {tarball: https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf}
+    version: 1.13.3
     engines: {node: '>=18'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -1447,13 +1447,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@modelcontextprotocol/sdk@https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@cdf3508':
+  '@modelcontextprotocol/sdk@https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.6
+      eventsource-parser: 3.0.1
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
@@ -1675,7 +1676,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.1
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -1910,7 +1911,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -1960,7 +1961,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -2261,7 +2262,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -2295,7 +2296,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
Still dependant on the pkg.pr.new link cause https://github.com/modelcontextprotocol/typescript-sdk/pull/570 still isn't merged, but hopefully that'll be fixed this week?