### PR TITLE
fix: header args include extra space in header value

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -534,7 +534,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   while (i < args.length) {
     if (args[i] === '--header' && i < args.length - 1) {
       const value = args[i + 1]
-      const match = value.match(/^([A-Za-z0-9_-]+):(.*)$/)
+      const match = value.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
       if (match) {
         headers[match[1]] = match[2]
       } else {


### PR DESCRIPTION
The logic for splitting header arguments into the header name and header value fails to account for the usual space in how headers are usually written.

For example:
The args `--header 'Authorization: Bearer abc123'` will be parsed as:
- `Authorization` header name 
- ` Bearer abc123` header value **with an extra space!**

The extra space in the header value might cause an authentication error in some cases.

It's expected that the header parsing will ignore these spaces between the `:` sign and the actual header value.