### PR TITLE
Upgrading @modelcontextprotocol/sdk to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "strict-url-sanitise": "^0.0.1"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "https://pkg.pr.new/geelen/typescript-sdk/@modelcontextprotocol/sdk@877f4bf",
+    "@modelcontextprotocol/sdk": "^1.17.3",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.10",
     "prettier": "^3.5.3",


### PR DESCRIPTION
Upgrading dependency on `@modelcontextprotocol/sdk` to `^1.17.3`, which now [supports auth flow for OIDC as well](https://github.com/modelcontextprotocol/typescript-sdk/pull/652).

[This PR](https://github.com/modelcontextprotocol/typescript-sdk/pull/570) has already been merged into @modelcontextprotocol/sdk, which is what is mentioned as the reason for the dependency change [here](https://github.com/geelen/mcp-remote/pull/119).