### PR TITLE
Fix OAuth authorization URLs missing required scope parameter

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { NodeOAuthClientProvider } from './node-oauth-client-provider'
+import type { OAuthProviderOptions } from './types'
+import * as mcpAuthConfig from './mcp-auth-config'
+import * as utils from './utils'
+
+// Mock the modules
+vi.mock('./mcp-auth-config')
+vi.mock('./utils')
+vi.mock('open')
+vi.mock('strict-url-sanitise')
+
+const mockWriteJsonFile = vi.mocked(mcpAuthConfig.writeJsonFile)
+const mockReadJsonFile = vi.mocked(mcpAuthConfig.readJsonFile)
+const mockDeleteConfigFile = vi.mocked(mcpAuthConfig.deleteConfigFile)
+const mockGetServerUrlHash = vi.mocked(utils.getServerUrlHash)
+
+describe('NodeOAuthClientProvider Scope Handling', () => {
+  let provider: NodeOAuthClientProvider
+  const options: OAuthProviderOptions = {
+    serverUrl: 'https://example.com',
+    callbackPort: 3000,
+    host: 'localhost',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock getServerUrlHash to return a consistent value
+    mockGetServerUrlHash.mockReturnValue('test-server-hash')
+    provider = new NodeOAuthClientProvider(options)
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('clientMetadata', () => {
+    it('should include default scope in client metadata', () => {
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('openid email profile')
+    })
+
+    it('should include custom scope from options in client metadata', () => {
+      const providerWithCustomScope = new NodeOAuthClientProvider({
+        ...options,
+        scopes: 'custom scope read write',
+      })
+
+      const metadata = providerWithCustomScope.clientMetadata
+      expect(metadata.scope).toBe('custom scope read write')
+    })
+
+    it('should include scope in client metadata with static OAuth metadata', () => {
+      const providerWithStaticMetadata = new NodeOAuthClientProvider({
+        ...options,
+        staticOAuthClientMetadata: {
+          redirect_uris: ['http://localhost:3000/oauth/callback'],
+          client_name: 'Custom Client',
+        },
+      })
+
+      const metadata = providerWithStaticMetadata.clientMetadata
+      expect(metadata.scope).toBe('openid email profile')
+      expect(metadata.client_name).toBe('Custom Client')
+    })
+  })
+
+  describe('scope extraction helper method', () => {
+    it('should extract scope from various registration response formats', () => {
+      // Test the private method through type assertion
+      const extractMethod = (provider as any).extractScopesFromRegistration.bind(provider)
+
+      // Test scope field
+      expect(extractMethod({ scope: 'custom scope' })).toBe('custom scope')
+
+      // Test default_scope field
+      expect(extractMethod({ default_scope: 'default scope' })).toBe('default scope')
+
+      // Test scopes array
+      expect(extractMethod({ scopes: ['read', 'write', 'admin'] })).toBe('read write admin')
+
+      // Test default_scopes array
+      expect(extractMethod({ default_scopes: ['openid', 'profile'] })).toBe('openid profile')
+
+      // Test fallback when no scope fields present
+      expect(extractMethod({})).toBe('openid email profile')
+
+      // Test priority order - scope takes precedence
+      expect(
+        extractMethod({
+          scope: 'priority scope',
+          default_scope: 'secondary scope',
+          scopes: ['array', 'scope'],
+        }),
+      ).toBe('priority scope')
+    })
+  })
+
+  describe('scope extraction from registration response', () => {
+    it('should extract scope from registration response', async () => {
+      const registrationResponse = {
+        client_id: 'test-client-id',
+        scope: 'openid email profile custom',
+      }
+
+      await provider.saveClientInformation(registrationResponse as any)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'client_info.json', registrationResponse)
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', { scopes: 'openid email profile custom' })
+    })
+
+    it('should extract default_scope from registration response', async () => {
+      const registrationResponse = {
+        client_id: 'test-client-id',
+        default_scope: 'openid email',
+      }
+
+      await provider.saveClientInformation(registrationResponse as any)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', { scopes: 'openid email' })
+    })
+
+    it('should handle array scopes from registration response', async () => {
+      const registrationResponse = {
+        client_id: 'test-client-id',
+        scopes: ['openid', 'email', 'profile'],
+      }
+
+      await provider.saveClientInformation(registrationResponse as any)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', { scopes: 'openid email profile' })
+    })
+
+    it('should handle array default_scopes from registration response', async () => {
+      const registrationResponse = {
+        client_id: 'test-client-id',
+        default_scopes: ['openid', 'email'],
+      }
+
+      await provider.saveClientInformation(registrationResponse as any)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', { scopes: 'openid email' })
+    })
+
+    it('should use fallback scope when none provided in registration response', async () => {
+      const registrationResponse = {
+        client_id: 'test-client-id',
+      }
+
+      await provider.saveClientInformation(registrationResponse as any)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', { scopes: 'openid email profile' })
+    })
+  })
+
+  describe('scope inclusion in authorization URL', () => {
+    it('should include default scope in authorization URL', async () => {
+      const authUrl = new URL('https://auth.example.com/oauth/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('openid email profile')
+    })
+
+    it('should include custom scope from options in authorization URL', async () => {
+      const providerWithCustomScope = new NodeOAuthClientProvider({
+        ...options,
+        scopes: 'custom scope read write',
+      })
+
+      const authUrl = new URL('https://auth.example.com/oauth/authorize')
+      await providerWithCustomScope.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('custom scope read write')
+    })
+
+    it('should include updated scopes after registration in authorization URL', async () => {
+      // Start with default scopes
+      const provider = new NodeOAuthClientProvider(options)
+
+      // Simulate scopes being updated from registration response
+      ;(provider as any)._scopes = 'openid email profile custom'
+
+      const authUrl = new URL('https://auth.example.com/oauth/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('openid email profile custom')
+    })
+
+    it('should include resource parameter alongside scope', async () => {
+      const providerWithResource = new NodeOAuthClientProvider({
+        ...options,
+        authorizeResource: 'test-resource',
+        scopes: 'openid email',
+      })
+
+      const authUrl = new URL('https://auth.example.com/oauth/authorize')
+      await providerWithResource.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('openid email')
+      expect(authUrl.searchParams.get('resource')).toBe('test-resource')
+    })
+  })
+
+  describe('scope loading from storage', () => {
+    it('should load stored scopes when getting client information', async () => {
+      const clientInfo = { client_id: 'test-client-id' }
+      const scopesData = { scopes: 'openid email profile custom' }
+
+      mockReadJsonFile
+        .mockResolvedValueOnce(clientInfo) // client_info.json
+        .mockResolvedValueOnce(scopesData) // scopes.json
+
+      const result = await provider.clientInformation()
+
+      expect(result).toEqual(clientInfo)
+      expect(mockReadJsonFile).toHaveBeenCalledWith('test-server-hash', 'client_info.json', expect.any(Object))
+      expect(mockReadJsonFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json', expect.any(Object))
+
+      // Verify scopes were loaded into the provider
+      expect((provider as any)._scopes).toBe('openid email profile custom')
+    })
+
+    it('should handle missing scopes file gracefully', async () => {
+      const clientInfo = { client_id: 'test-client-id' }
+
+      mockReadJsonFile
+        .mockResolvedValueOnce(clientInfo) // client_info.json
+        .mockResolvedValueOnce(undefined) // scopes.json (not found)
+
+      const result = await provider.clientInformation()
+
+      expect(result).toEqual(clientInfo)
+    })
+  })
+
+  describe('credential invalidation', () => {
+    it('should delete scopes when invalidating all credentials', async () => {
+      await provider.invalidateCredentials('all')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json')
+    })
+
+    it('should delete scopes when invalidating client credentials', async () => {
+      await provider.invalidateCredentials('client')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-server-hash', 'client_info.json')
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-server-hash', 'scopes.json')
+    })
+
+    it('should not delete scopes when invalidating only tokens', async () => {
+      await provider.invalidateCredentials('tokens')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-server-hash', 'tokens.json')
+      expect(mockDeleteConfigFile).not.toHaveBeenCalledWith('test-server-hash', 'scopes.json')
+    })
+  })
+})

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -27,6 +27,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private staticOAuthClientMetadata: StaticOAuthClientMetadata
   private staticOAuthClientInfo: StaticOAuthClientInformationFull
   private authorizeResource: string | undefined
+  private _scopes: string | undefined
   private _state: string
 
   /**
@@ -43,6 +44,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.staticOAuthClientMetadata = options.staticOAuthClientMetadata
     this.staticOAuthClientInfo = options.staticOAuthClientInfo
     this.authorizeResource = options.authorizeResource
+    this._scopes = options.scopes || 'openid email profile'
     this._state = randomUUID()
   }
 
@@ -60,6 +62,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       client_uri: this.clientUri,
       software_id: this.softwareId,
       software_version: this.softwareVersion,
+      scope: this._scopes,
       ...this.staticOAuthClientMetadata,
     }
   }
@@ -83,8 +86,34 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       'client_info.json',
       OAuthClientInformationFullSchema,
     )
+
+    // Also load stored scopes from registration (these override options-based scopes)
+    if (clientInfo) {
+      const scopesData = await readJsonFile<{ scopes: string }>(this.serverUrlHash, 'scopes.json', {
+        parseAsync: async (data: any) => data,
+      })
+      if (scopesData?.scopes) {
+        this._scopes = scopesData.scopes
+        if (DEBUG) debugLog('Loaded stored scopes from registration', { scopes: this._scopes })
+      }
+    }
+
     if (DEBUG) debugLog('Client info result:', clientInfo ? 'Found' : 'Not found')
     return clientInfo
+  }
+
+  /**
+   * Extracts scopes from OAuth registration response
+   * @param clientInfo The client registration response
+   * @returns The extracted scopes as a space-separated string
+   */
+  private extractScopesFromRegistration(clientInfo: any): string {
+    if (clientInfo.scope) return clientInfo.scope
+    if (clientInfo.default_scope) return clientInfo.default_scope
+    if (Array.isArray(clientInfo.scopes)) return clientInfo.scopes.join(' ')
+    if (Array.isArray(clientInfo.default_scopes)) return clientInfo.default_scopes.join(' ')
+
+    return 'openid email profile'
   }
 
   /**
@@ -93,7 +122,14 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   async saveClientInformation(clientInformation: OAuthClientInformationFull): Promise<void> {
     if (DEBUG) debugLog('Saving client info', { client_id: clientInformation.client_id })
+
+    const scopes = this.extractScopesFromRegistration(clientInformation as any)
+
+    if (DEBUG) debugLog('Extracted scopes from registration response', { scopes })
+    this._scopes = scopes
+
     await writeJsonFile(this.serverUrlHash, 'client_info.json', clientInformation)
+    await writeJsonFile(this.serverUrlHash, 'scopes.json', { scopes })
   }
 
   /**
@@ -174,6 +210,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       authorizationUrl.searchParams.set('resource', this.authorizeResource)
     }
 
+    authorizationUrl.searchParams.set('scope', this._scopes)
+    if (DEBUG) debugLog('Added scope parameter to authorization URL', { scopes: this._scopes })
+
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 
     if (DEBUG) debugLog('Redirecting to authorization URL', authorizationUrl.toString())
@@ -220,12 +259,14 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
           deleteConfigFile(this.serverUrlHash, 'client_info.json'),
           deleteConfigFile(this.serverUrlHash, 'tokens.json'),
           deleteConfigFile(this.serverUrlHash, 'code_verifier.txt'),
+          deleteConfigFile(this.serverUrlHash, 'scopes.json'),
         ])
         if (DEBUG) debugLog('All credentials invalidated')
         break
 
       case 'client':
-        await deleteConfigFile(this.serverUrlHash, 'client_info.json')
+        await Promise.all([deleteConfigFile(this.serverUrlHash, 'client_info.json'), deleteConfigFile(this.serverUrlHash, 'scopes.json')])
+        this._scopes = this.options.scopes || 'openid email profile'
         if (DEBUG) debugLog('Client information invalidated')
         break
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface OAuthProviderOptions {
   staticOAuthClientInfo?: StaticOAuthClientInformationFull
   /** Resource parameter to send to the authorization server */
   authorizeResource?: string
+  /** OAuth scopes to request (default: 'openid email profile') */
+  scopes?: string
 }
 
 /**


### PR DESCRIPTION
## Problem

OAuth providers like Google require the `scope` parameter in authorization URLs as per RFC 6749. Currently, mcp-remote fails to authenticate with these providers because the scope parameter is missing from the authorization request, resulting in errors like "Missing required parameter: scope".

## Solution

This PR adds comprehensive OAuth scope parameter support by:

### Core Changes
- **Extract scopes from registration responses** in multiple formats (scope, default_scope, scopes[], default_scopes[])
- **Store scopes persistently** in separate JSON files and load them during client initialization
- **Add scope parameter to authorization URLs** to satisfy OAuth provider requirements
- **Add scopes parameter to OAuthProviderOptions** for consistent property initialization
- **Add helper method** `extractScopesFromRegistration()` for better code organization

### Implementation Details
- Scopes are extracted from OAuth registration responses and stored in `scopes.json`
- The `OAuthProviderOptions` interface now includes an optional `scopes` property
- Scope handling follows the same pattern as other optional properties (initialized from options with fallback)
- Authorization URLs include the scope parameter automatically
- Credential invalidation properly cleans up stored scopes

### Testing
Added comprehensive test suite (18 test cases) covering:
- Scope extraction from various registration response formats
- Scope parameter inclusion in client metadata and authorization URLs
- Scope loading from storage
- Custom scopes from options
- Credential invalidation with scope cleanup

## Compatibility
- **Backward compatible** - existing installations continue working with default scopes
- **No breaking changes** - all existing APIs remain unchanged
- **Graceful fallbacks** - handles missing scope data appropriately

## Testing Done
- All 18 OAuth-related tests pass
- Manual testing with OAuth providers that require scope parameter
- Verified no changes to `utils.test.ts` for upstream compatibility

Fixes authentication issues with OAuth providers that strictly require the scope parameter in authorization requests.