### PR TITLE
Fix OAuth scope parameter handling while preserving custom scopes

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NodeOAuthClientProvider } from './node-oauth-client-provider'
+import * as mcpAuthConfig from './mcp-auth-config'
+import type { OAuthProviderOptions } from './types'
+
+vi.mock('./mcp-auth-config')
+vi.mock('./utils', () => ({
+  getServerUrlHash: () => 'test-hash',
+  log: vi.fn(),
+  debugLog: vi.fn(),
+  DEBUG: false,
+  MCP_REMOTE_VERSION: '1.0.0',
+}))
+
+describe('NodeOAuthClientProvider', () => {
+  let provider: NodeOAuthClientProvider
+  let mockReadJsonFile: any
+  let mockWriteJsonFile: any
+  let mockDeleteConfigFile: any
+
+  const defaultOptions: OAuthProviderOptions = {
+    serverUrl: 'https://example.com',
+    callbackPort: 8080,
+    host: 'localhost',
+  }
+
+  beforeEach(() => {
+    mockReadJsonFile = vi.mocked(mcpAuthConfig.readJsonFile)
+    mockWriteJsonFile = vi.mocked(mcpAuthConfig.writeJsonFile)
+    mockDeleteConfigFile = vi.mocked(mcpAuthConfig.deleteConfigFile)
+
+    mockReadJsonFile.mockResolvedValue(undefined)
+    mockWriteJsonFile.mockResolvedValue(undefined)
+    mockDeleteConfigFile.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('custom scopes preservation', () => {
+    it('should use custom scope from staticOAuthClientMetadata', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'custom read write',
+        } as any,
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('custom read write')
+    })
+
+    it('should prioritize custom scope over default scopes', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'user:email repo',
+        } as any,
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('user:email repo')
+    })
+
+    it('should use default scopes when no custom scope provided', () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('openid email profile')
+    })
+
+    it('should include scope in authorization URL with custom scope', async () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'github read:user',
+        } as any,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('github read:user')
+    })
+  })
+
+  describe('extracted scopes from registration', () => {
+    beforeEach(() => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+    })
+
+    it('should extract scope from registration response', async () => {
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        scope: 'extracted custom scopes',
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-hash', 'scopes.json', {
+        scopes: 'extracted custom scopes',
+      })
+    })
+
+    it('should extract default_scope from registration response', async () => {
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        default_scope: 'default extracted scopes',
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-hash', 'scopes.json', {
+        scopes: 'default extracted scopes',
+      })
+    })
+
+    it('should extract scopes array from registration response', async () => {
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        scopes: ['scope1', 'scope2', 'scope3'],
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-hash', 'scopes.json', {
+        scopes: 'scope1 scope2 scope3',
+      })
+    })
+
+    it('should extract default_scopes array from registration response', async () => {
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        default_scopes: ['default1', 'default2'],
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-hash', 'scopes.json', {
+        scopes: 'default1 default2',
+      })
+    })
+
+    it('should fallback to default when no scopes in registration', async () => {
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).toHaveBeenCalledWith('test-hash', 'scopes.json', {
+        scopes: 'openid email profile',
+      })
+    })
+
+    it('should load extracted scopes and use in clientMetadata', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ client_id: 'test-client' }).mockResolvedValueOnce({ scopes: 'loaded extracted scopes' })
+
+      await provider.clientInformation()
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('loaded extracted scopes')
+    })
+
+    it('should include extracted scopes in authorization URL', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ client_id: 'test-client' }).mockResolvedValueOnce({ scopes: 'loaded scopes for auth' })
+
+      await provider.clientInformation()
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.get('scope')).toBe('loaded scopes for auth')
+    })
+  })
+
+  describe('scope priority and behavior', () => {
+    it('should NOT extract scopes when custom scope is provided', async () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'custom priority scope',
+        } as any,
+      })
+
+      const clientInfo = {
+        client_id: 'test-client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        scope: 'registration scope should be ignored',
+      }
+
+      await provider.saveClientInformation(clientInfo)
+
+      expect(mockWriteJsonFile).not.toHaveBeenCalledWith('test-hash', 'scopes.json', expect.anything())
+    })
+
+    it('should NOT load stored scopes when custom scope is provided', async () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'custom override scope',
+        } as any,
+      })
+
+      mockReadJsonFile.mockResolvedValueOnce({ client_id: 'test-client' })
+
+      await provider.clientInformation()
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('custom override scope')
+    })
+
+    it('should respect staticOAuthClientMetadata spreading with custom scope', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'custom scope',
+          client_name: 'Custom Client Name',
+          some_other_field: 'custom value',
+        } as any,
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('custom scope')
+      expect(metadata.client_name).toBe('Custom Client Name')
+      expect((metadata as any).some_other_field).toBe('custom value')
+    })
+  })
+
+  describe('credential invalidation', () => {
+    beforeEach(() => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+    })
+
+    it('should clean up scopes file when invalidating all credentials', async () => {
+      await provider.invalidateCredentials('all')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', 'scopes.json')
+    })
+
+    it('should clean up scopes file when invalidating client credentials', async () => {
+      await provider.invalidateCredentials('client')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', 'scopes.json')
+    })
+
+    it('should not clean up scopes file when invalidating only tokens', async () => {
+      await provider.invalidateCredentials('tokens')
+
+      expect(mockDeleteConfigFile).not.toHaveBeenCalledWith('test-hash', 'scopes.json')
+    })
+
+    it('should reset to default scopes after client invalidation', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ client_id: 'test-client' }).mockResolvedValueOnce({ scopes: 'extracted scopes' })
+
+      await provider.clientInformation()
+      expect(provider.clientMetadata.scope).toBe('extracted scopes')
+
+      await provider.invalidateCredentials('client')
+
+      expect(provider.clientMetadata.scope).toBe('openid email profile')
+    })
+  })
+
+  describe('backward compatibility', () => {
+    it('should work exactly like before when using staticOAuthClientMetadata.scope', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: {
+          scope: 'existing custom scope',
+          client_name: 'My Custom Client',
+        } as any,
+      })
+
+      const metadata = provider.clientMetadata
+
+      expect(metadata).toMatchObject({
+        scope: 'existing custom scope',
+        client_name: 'My Custom Client',
+        redirect_uris: ['http://localhost:8080/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        software_id: '2e6dc280-f3c3-4e01-99a7-8181dbd1d23d',
+        software_version: '1.0.0',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Problem

PR #145 fixed the "Missing required parameter: scope" error with OAuth providers like Google, but it introduced a regression that broke existing users who relied on `--static-oauth-client-metadata '{"scope": "custom scopes"}'` for custom scope configuration.

**Root Cause:** The original implementation always forced scopes to be hardcoded defaults (`'openid email profile'`), overriding any custom scope provided in `staticOAuthClientMetadata`.

## Solution

This PR fixes the regression while preserving the original OAuth scope parameter fix. It implements a proper scope priority system:

### Scope Priority (Backward Compatible)
1. **Custom scope from `staticOAuthClientMetadata.scope`** (user's custom scope) - **HIGHEST PRIORITY**
2. Extracted scopes from registration response 
3. Default scopes (`'openid email profile'`) as fallback only

### Core Changes
- **Preserve custom scopes**: `staticOAuthClientMetadata.scope` always takes precedence
- **Add scope parameter to authorization URLs**: Fixes "Missing required parameter: scope" errors  
- **Extract scopes from registration responses**: Handles multiple formats (scope, default_scope, scopes[], default_scopes[])
- **Smart scope extraction**: Only extracts when no custom scope is provided
- **Proper cleanup**: Stored scopes are cleaned up during credential invalidation

### Implementation Details
- `getEffectiveScope()`: Determines which scope to use based on priority
- `extractScopesFromRegistration()`: Handles different scope formats from OAuth providers
- Conditional scope extraction: Respects existing `staticOAuthClientMetadata.scope`
- Persistent scope storage: Extracted scopes stored in `scopes.json` and loaded on startup
- Authorization URL enhancement: Adds effective scope parameter automatically

### Testing
Added 19 comprehensive test cases covering:
- **Custom scopes preservation**: Verifies `staticOAuthClientMetadata.scope` always takes priority
- **Scope extraction**: Tests all registration response formats (scope, default_scope, scopes[], default_scopes[])  
- **Priority behavior**: Ensures custom scopes are never overridden
- **Backward compatibility**: Existing usage patterns work exactly as before
- **Credential invalidation**: Proper cleanup of stored scopes
- **Authorization URLs**: Correct scope parameter inclusion

## Compatibility

### ✅ Backward Compatible
- **Existing custom scope users**: `--static-oauth-client-metadata '{"scope": "custom scopes"}'` works exactly as before
- **No breaking changes**: All existing APIs remain unchanged  
- **Graceful fallbacks**: Missing scope data handled appropriately

### ✅ Fixes Original Issue  
- **OAuth providers like Google**: Now receive required scope parameter in authorization URLs
- **Dynamic client registration**: Scopes extracted from registration responses
- **Default behavior**: Users without custom scopes get sensible defaults

## Testing Done
- All 19 OAuth tests pass ✅
- No changes to `utils.test.ts` (upstream compatibility) ✅ 
- Manual testing with OAuth providers requiring scope parameter ✅
- Verified existing custom scope workflows still work ✅

## Example Usage

**Before (broken in v0.1.20):**
```bash
# This stopped working in v0.1.20 - custom scope was ignored
mcp-remote --static-oauth-client-metadata '{"scope": "user:email repo"}' --server-url https://api.example.com
```

**After (fixed in this PR):**
```bash  
# Works perfectly - custom scope is preserved and used
mcp-remote --static-oauth-client-metadata '{"scope": "user:email repo"}' --server-url https://api.example.com
# Authorization URL includes: &scope=user:email+repo

# Also works - uses extracted scopes from registration
mcp-remote --server-url https://google-oauth-provider.com  
# Authorization URL includes: &scope=openid+email+profile (or extracted scopes)
```

This fix ensures both existing users with custom scopes and new users with providers like Google have a seamless OAuth experience.