### PR TITLE
Fix handling of server-initiated messages

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -113,6 +113,7 @@ export function createMessageTransformer({
     const messageId = message.id
     if (!messageId) return message
     const originalRequest = pendingRequests.get(messageId)
+    if (!originalRequest) return message
     pendingRequests.delete(messageId)
     return transformResponseFunction?.(originalRequest, message) ?? message
   }


### PR DESCRIPTION
Fixes #[155](https://github.com/geelen/mcp-remote/issues/155)

**Problem**
The proxy would fail transferring server-initiated messages (like ping) to end-client as it tried to access properties on an undefined originalRequest, assuming all requests arrived from end-client originally (which is not necessarily true, e.g. the case of server-initiated pings).

**Solution**
Added an early return in `interceptResponse` (`src/lib/utils.ts`) when no matching request exists in pendingRequests, allowing these messages to pass through safely.

**Testing**
Added tests to verify the proxy correctly handles:
- Server-initiated requests (e.g., ping messages)
- Orphaned responses without matching client requests (not supposed to happen, but this is another way to look at this fix)