### PR TITLE
Reduce file permissions for config files to protect OAuth secrets

### DIFF
--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -164,7 +164,7 @@ export async function writeJsonFile(serverUrlHash: string, filename: string, dat
   try {
     await ensureConfigDir()
     const filePath = getConfigFilePath(serverUrlHash, filename)
-    await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8')
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 })
   } catch (error) {
     log(`Error writing ${filename}:`, error)
     throw error
@@ -198,7 +198,7 @@ export async function writeTextFile(serverUrlHash: string, filename: string, tex
   try {
     await ensureConfigDir()
     const filePath = getConfigFilePath(serverUrlHash, filename)
-    await fs.writeFile(filePath, text, 'utf-8')
+    await fs.writeFile(filePath, text, { encoding: 'utf-8', mode: 0o600 })
   } catch (error) {
     log(`Error writing ${filename}:`, error)
     throw error


### PR DESCRIPTION
Currently, configuration files under `~/.mcp-auth/` are created with 644 permissions which allows all users to read the contents. These files contain OAuth tokens and PKCEs which should not be accessible to anyone but the user they belong to.

This PR changes those file permissions to 600 so that only the current user can read them.