### PR TITLE
feat: Add --silent flag to suppress log output

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -418,6 +418,19 @@ describe('Feature: Command Line Arguments Parsing', () => {
 
     consoleSpy.mockRestore()
   })
+
+  it('Scenario: Suppresses LOG when using --silent', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const args = ['https://example.com/sse', '--auth-timeout', '45', '--silent']
+    const usage = 'test usage'
+
+    const result = await parseCommandLineArgs(args, usage)
+
+    expect(result.authTimeoutMs).toBe(45000)
+    expect(consoleSpy).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
 })
 
 describe('Feature: Tool Filtering with Ignore Patterns', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,6 +32,7 @@ export { MCP_REMOTE_VERSION }
 const pid = process.pid
 // Global debug flag
 export let DEBUG = false
+export let SILENT = false
 
 // Helper function for timestamp formatting
 function getTimestamp(): string {
@@ -72,8 +73,10 @@ export function debugLog(message: string, ...args: any[]) {
 }
 
 export function log(str: string, ...rest: unknown[]) {
-  // Using stderr so that it doesn't interfere with stdout
-  console.error(`[${pid}] ${str}`, ...rest)
+  if (!SILENT) {
+    // Using stderr so that it doesn't interfere with stdout
+    console.error(`[${pid}] ${str}`, ...rest)
+  }
 
   // If debug mode is on, also log to debug file
   debugLog(str, ...rest)
@@ -630,6 +633,13 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   if (debug) {
     DEBUG = true
     log('Debug mode enabled - detailed logs will be written to ~/.mcp-auth/')
+  }
+
+    // Check for silent flag
+  const silent = args.includes('--silent')
+  if (silent) {
+    SILENT = true
+    log('Silent mode enabled - stderr output will be suppressed, except when --debug is also enabled')
   }
 
   const enableProxy = args.includes('--enable-proxy')


### PR DESCRIPTION
Something we're running into is initialization steps log to the console. This makes it hard to capture stderr when spun as a subprocess without patching the runtime. This PR adds a new `--silent` flag to suppress these (default) logs, though if `--debug` is set to true one can still capture output, which is helpful. 