### PR TITLE
fix: isolate OAuth cache by resource and headers (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ To bypass authentication, or to emit custom headers on all requests to your remo
 },
 ```
 
+### Multiple Instances
+
+To run multiple instances of the same remote server with different configurations (e.g., different Atlassian tenants), use the `--resource` flag to isolate OAuth sessions:
+
+```json
+{
+  "mcpServers": {
+    "atlassian_tenant1": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.atlassian.com/v1/sse",
+        "--resource",
+        "https://tenant1.atlassian.net/"
+      ]
+    },
+    "atlassian_tenant2": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.atlassian.com/v1/sse",
+        "--resource",
+        "https://tenant2.atlassian.net/"
+      ]
+    }
+  }
+}
+```
+
+Each unique combination of server URL, resource, and custom headers will maintain separate OAuth sessions and token storage.
+
 ### Flags
 
 * If `npx` is producing errors, consider adding `-y` as the first argument to auto-accept the installation of the `mcp-remote` package.

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,15 +13,7 @@ import { EventEmitter } from 'events'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { ListResourcesResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
-import {
-  parseCommandLineArgs,
-  setupSignalHandlers,
-  log,
-  MCP_REMOTE_VERSION,
-  getServerUrlHash,
-  connectToRemoteServer,
-  TransportStrategy,
-} from './lib/utils'
+import { parseCommandLineArgs, setupSignalHandlers, log, MCP_REMOTE_VERSION, connectToRemoteServer, TransportStrategy } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { createLazyAuthCoordinator } from './lib/coordination'
 
@@ -37,12 +29,10 @@ async function runClient(
   staticOAuthClientMetadata: StaticOAuthClientMetadata,
   staticOAuthClientInfo: StaticOAuthClientInformationFull,
   authTimeoutMs: number,
+  serverUrlHash: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
-
-  // Get the server URL hash for lockfile operations
-  const serverUrlHash = getServerUrlHash(serverUrl)
 
   // Create a lazy auth coordinator
   const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
@@ -55,6 +45,7 @@ async function runClient(
     clientName: 'MCP CLI Client',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
+    serverUrlHash,
   })
 
   // Create the client
@@ -161,7 +152,17 @@ async function runClient(
 // Parse command-line arguments and run the client
 parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://server-url> [callback-port] [--debug]')
   .then(
-    ({ serverUrl, callbackPort, headers, transportStrategy, host, staticOAuthClientMetadata, staticOAuthClientInfo, authTimeoutMs }) => {
+    ({
+      serverUrl,
+      callbackPort,
+      headers,
+      transportStrategy,
+      host,
+      staticOAuthClientMetadata,
+      staticOAuthClientInfo,
+      authTimeoutMs,
+      serverUrlHash,
+    }) => {
       return runClient(
         serverUrl,
         callbackPort,
@@ -171,6 +172,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
         staticOAuthClientMetadata,
         staticOAuthClientInfo,
         authTimeoutMs,
+        serverUrlHash,
       )
     },
   )

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -9,7 +9,7 @@ import {
 import type { OAuthProviderOptions, StaticOAuthClientMetadata } from './types'
 import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile } from './mcp-auth-config'
 import { StaticOAuthClientInformationFull } from './types'
-import { getServerUrlHash, log, debugLog, MCP_REMOTE_VERSION } from './utils'
+import { log, debugLog, MCP_REMOTE_VERSION } from './utils'
 import { sanitizeUrl } from 'strict-url-sanitise'
 import { randomUUID } from 'node:crypto'
 
@@ -34,7 +34,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * @param options Configuration options for the provider
    */
   constructor(readonly options: OAuthProviderOptions) {
-    this.serverUrlHash = getServerUrlHash(options.serverUrl)
+    this.serverUrlHash = options.serverUrlHash
     this.callbackPath = options.callbackPath || '/oauth/callback'
     this.clientName = options.clientName || 'MCP CLI Client'
     this.clientUri = options.clientUri || 'https://github.com/modelcontextprotocol/mcp-cli'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface OAuthProviderOptions {
   staticOAuthClientInfo?: StaticOAuthClientInformationFull
   /** Resource parameter to send to the authorization server */
   authorizeResource?: string
+  /** Pre-calculated server URL hash for cache isolation */
+  serverUrlHash: string
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,15 +11,7 @@
 
 import { EventEmitter } from 'events'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import {
-  connectToRemoteServer,
-  log,
-  mcpProxy,
-  parseCommandLineArgs,
-  setupSignalHandlers,
-  getServerUrlHash,
-  TransportStrategy,
-} from './lib/utils'
+import { connectToRemoteServer, log, mcpProxy, parseCommandLineArgs, setupSignalHandlers, TransportStrategy } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator } from './lib/coordination'
@@ -38,12 +30,10 @@ async function runProxy(
   authorizeResource: string,
   ignoredTools: string[],
   authTimeoutMs: number,
+  serverUrlHash: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
-
-  // Get the server URL hash for lockfile operations
-  const serverUrlHash = getServerUrlHash(serverUrl)
 
   // Create a lazy auth coordinator
   const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
@@ -57,6 +47,7 @@ async function runProxy(
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
     authorizeResource,
+    serverUrlHash,
   })
 
   // Create the STDIO transport for local connections
@@ -160,6 +151,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       authorizeResource,
       ignoredTools,
       authTimeoutMs,
+      serverUrlHash,
     }) => {
       return runProxy(
         serverUrl,
@@ -172,6 +164,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
         authorizeResource,
         ignoredTools,
         authTimeoutMs,
+        serverUrlHash,
       )
     },
   )


### PR DESCRIPTION
Fixes #25

## Problem
Multiple instances connecting to the same server URL with different `--resource` flags share OAuth sessions and connect to the wrong tenant.

## Solution
Include `authorizeResource` and custom headers in the `serverUrlHash` calculation to isolate OAuth sessions per unique configuration.

## Changes
- Modified `getServerUrlHash()` to include resource and headers in hash calculation
- Calculate hash once in `parseCommandLineArgs()` with all parameters
- Pass hash through stack to `NodeOAuthClientProvider`
- Each unique config gets isolated lockfile and token storage

## Testing
- ✅ Added 6 unit tests for hash generation (all passing, 50/50 total)
- ✅ Tested with real multi-tenant Atlassian setup
- ✅ Both instances connect to correct tenants
- ✅ Separate OAuth sessions maintained
- ✅ Backward compatible (one-time re-auth for existing users)

## Example (multiple Atlassian tenants)
```json
{
  "mcpServers": {
    "atlassian_tenant1": {
      "command": "npx",
      "args": ["mcp-remote", "https://mcp.atlassian.com/v1/sse", "--resource", "https://tenant1.atlassian.net/"]
    },
    "atlassian_tenant2": {
      "command": "npx",
      "args": ["mcp-remote", "https://mcp.atlassian.com/v1/sse", "--resource", "https://tenant2.atlassian.net/"]
    }
  }
}
```