### PR TITLE
Fix OAuth callback server to bind to localhost only

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -641,7 +641,7 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     options.events.emit('auth-code-received', code)
   })
 
-  const server = app.listen(options.port, () => {
+  const server = app.listen(options.port, '127.0.0.1', () => {
     log(`OAuth callback server running at http://127.0.0.1:${options.port}`)
   })
 


### PR DESCRIPTION
## 📋 Summary

Fixed issue where OAuth callback server was binding to `0.0.0.0` (all network interfaces) instead of `127.0.0.1` (localhost only), exposing the OAuth authorization endpoint to the local network during authentication flows.

## 🐛 Problem

The OAuth callback server in `setupOAuthCallbackServer()` was listening on all interfaces, contradicting its own log message:

```javascript
const server = app.listen(options.port, () => {
  log(`OAuth callback server running at http://127.0.0.1:${options.port}`)
})
```

Despite the log claiming `http://127.0.0.1:${options.port}`, the server was actually binding to `0.0.0.0:PORT`, making it accessible from the network rather than localhost only.

1. Express 4.21.2 delegates to http.Server.listen():
   https://github.com/expressjs/express/blob/4.21.2/lib/application.js#L633-L636

2. http.Server inherits from net.Server:
   https://github.com/nodejs/node/blob/6c9a7cd61ef4be527da9cfa86e42edb17c3ec123/lib/_http_server.js#L574-L575

3. net.Server.listen() defaults to 0.0.0.0 when hostname omitted:
   https://github.com/nodejs/node/blob/6c9a7cd61ef4be527da9cfa86e42edb17c3ec123/lib/net.js#L149-L150

## ✅ Solution

Explicitly bind the Express server to `127.0.0.1`:

```javascript
const server = app.listen(options.port, '127.0.0.1', () => {
  log(`OAuth callback server running at http://127.0.0.1:${options.port}`)
})
```

## 📝 Changes

**File:** `src/lib/utils.ts`
- **Line 515:** Added `'127.0.0.1'` as second parameter to `app.listen()`

## 🔍 Impact

- **Breaking:** None - callback URLs use `localhost`/`127.0.0.1` in OAuth registration
- **Compatibility:** Maintains existing behavior for all OAuth providers
- **Security:** Prevents network exposure of OAuth callback endpoint