### PR TITLE
Implement Protected Resource Metadata Discovery (RFC 9728) for MCP Authorization Compliance

### DIFF
--- a/src/lib/protected-resource-metadata.test.ts
+++ b/src/lib/protected-resource-metadata.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  parseWWWAuthenticateHeader,
+  buildProtectedResourceMetadataUrls,
+  discoverProtectedResourceMetadata,
+  getAuthorizationServerUrl,
+  type ProtectedResourceMetadata,
+} from './protected-resource-metadata'
+
+describe('protected-resource-metadata', () => {
+  describe('parseWWWAuthenticateHeader', () => {
+    it('should parse resource_metadata URL from header', () => {
+      const header = 'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.resourceMetadataUrl).toBe('https://mcp.example.com/.well-known/oauth-protected-resource')
+    })
+
+    it('should parse scope from header', () => {
+      const header = 'Bearer scope="files:read files:write"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.scope).toBe('files:read files:write')
+    })
+
+    it('should parse both resource_metadata and scope', () => {
+      const header = 'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", scope="read write"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.resourceMetadataUrl).toBe('https://mcp.example.com/.well-known/oauth-protected-resource')
+      expect(result.scope).toBe('read write')
+    })
+
+    it('should parse error and error_description', () => {
+      const header = 'Bearer error="invalid_request", error_description="No access token was provided"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.error).toBe('invalid_request')
+      expect(result.errorDescription).toBe('No access token was provided')
+    })
+
+    it('should parse Supabase-style WWW-Authenticate header', () => {
+      const header =
+        'Bearer error="invalid_request", error_description="No access token was provided in this request", resource_metadata="https://mcp.supabase.com/.well-known/oauth-protected-resource/mcp"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.error).toBe('invalid_request')
+      expect(result.errorDescription).toBe('No access token was provided in this request')
+      expect(result.resourceMetadataUrl).toBe('https://mcp.supabase.com/.well-known/oauth-protected-resource/mcp')
+    })
+
+    it('should handle empty header', () => {
+      const result = parseWWWAuthenticateHeader('')
+
+      expect(result.resourceMetadataUrl).toBeUndefined()
+      expect(result.scope).toBeUndefined()
+    })
+
+    it('should handle header without Bearer prefix', () => {
+      const header = 'resource_metadata="https://example.com/prm"'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.resourceMetadataUrl).toBe('https://example.com/prm')
+    })
+
+    it('should handle unquoted values', () => {
+      const header = 'Bearer error=invalid_token'
+      const result = parseWWWAuthenticateHeader(header)
+
+      expect(result.error).toBe('invalid_token')
+    })
+  })
+
+  describe('buildProtectedResourceMetadataUrls', () => {
+    it('should build path-specific and root URLs for URL with path', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://mcp.example.com/mcp')
+
+      expect(urls).toEqual([
+        'https://mcp.example.com/.well-known/oauth-protected-resource/mcp',
+        'https://mcp.example.com/.well-known/oauth-protected-resource',
+      ])
+    })
+
+    it('should build only root URL for URL without path', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://mcp.example.com')
+
+      expect(urls).toEqual(['https://mcp.example.com/.well-known/oauth-protected-resource'])
+    })
+
+    it('should build only root URL for URL with just slash', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://mcp.example.com/')
+
+      expect(urls).toEqual(['https://mcp.example.com/.well-known/oauth-protected-resource'])
+    })
+
+    it('should handle deep paths', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://api.example.com/v1/mcp/server')
+
+      expect(urls).toEqual([
+        'https://api.example.com/.well-known/oauth-protected-resource/v1/mcp/server',
+        'https://api.example.com/.well-known/oauth-protected-resource',
+      ])
+    })
+
+    it('should handle URLs with ports', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://localhost:8080/mcp')
+
+      expect(urls).toEqual([
+        'https://localhost:8080/.well-known/oauth-protected-resource/mcp',
+        'https://localhost:8080/.well-known/oauth-protected-resource',
+      ])
+    })
+
+    it('should strip trailing slash from path', () => {
+      const urls = buildProtectedResourceMetadataUrls('https://example.com/mcp/')
+
+      expect(urls).toEqual([
+        'https://example.com/.well-known/oauth-protected-resource/mcp',
+        'https://example.com/.well-known/oauth-protected-resource',
+      ])
+    })
+  })
+
+  describe('discoverProtectedResourceMetadata', () => {
+    let originalFetch: typeof global.fetch
+
+    beforeEach(() => {
+      originalFetch = global.fetch
+    })
+
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it('should use resource_metadata URL from WWW-Authenticate header', async () => {
+      const mockMetadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com/mcp',
+        authorization_servers: ['https://auth.example.com'],
+        scopes_supported: ['read', 'write'],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockMetadata,
+      })
+
+      const header = 'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"'
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp', header)
+
+      expect(metadata).toEqual(mockMetadata)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://mcp.example.com/.well-known/oauth-protected-resource/mcp',
+        expect.objectContaining({
+          headers: { Accept: 'application/json' },
+        }),
+      )
+    })
+
+    it('should fall back to well-known URLs if header URL fails', async () => {
+      const mockMetadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com/mcp',
+        authorization_servers: ['https://auth.example.com'],
+      }
+
+      // First call (header URL) fails, second call (path-specific well-known) succeeds
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockMetadata,
+        })
+
+      const header = 'Bearer resource_metadata="https://mcp.example.com/invalid-url"'
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp', header)
+
+      expect(metadata).toEqual(mockMetadata)
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should try path-specific URL first when no header provided', async () => {
+      const mockMetadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com/mcp',
+        authorization_servers: ['https://auth.example.com'],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockMetadata,
+      })
+
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp')
+
+      expect(metadata).toEqual(mockMetadata)
+      expect(global.fetch).toHaveBeenCalledWith('https://mcp.example.com/.well-known/oauth-protected-resource/mcp', expect.any(Object))
+    })
+
+    it('should fall back to root well-known URL if path-specific fails', async () => {
+      const mockMetadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com',
+        authorization_servers: ['https://auth.example.com'],
+      }
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockMetadata,
+        })
+
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp')
+
+      expect(metadata).toEqual(mockMetadata)
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(global.fetch).toHaveBeenNthCalledWith(2, 'https://mcp.example.com/.well-known/oauth-protected-resource', expect.any(Object))
+    })
+
+    it('should return undefined if all discovery methods fail', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp')
+
+      expect(metadata).toBeUndefined()
+    })
+
+    it('should handle network errors gracefully', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.example.com/mcp')
+
+      expect(metadata).toBeUndefined()
+    })
+
+    it('should parse Supabase Protected Resource Metadata correctly', async () => {
+      const supabaseMetadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.supabase.com/mcp',
+        bearer_methods_supported: ['Bearer'],
+        authorization_servers: ['https://api.supabase.com'],
+        resource_documentation: 'https://api.supabase.com/api/mcp',
+        resource_name: 'Supabase MCP (Beta)',
+        scopes_supported: [
+          'organizations:read',
+          'projects:read',
+          'projects:write',
+          'database:write',
+          'database:read',
+          'analytics:read',
+          'secrets:read',
+          'edge_functions:read',
+          'edge_functions:write',
+          'environment:read',
+          'environment:write',
+          'storage:read',
+        ],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => supabaseMetadata,
+      })
+
+      const header =
+        'Bearer error="invalid_request", error_description="No access token was provided in this request", resource_metadata="https://mcp.supabase.com/.well-known/oauth-protected-resource/mcp"'
+      const metadata = await discoverProtectedResourceMetadata('https://mcp.supabase.com/mcp', header)
+
+      expect(metadata).toEqual(supabaseMetadata)
+      expect(metadata?.authorization_servers).toEqual(['https://api.supabase.com'])
+      expect(metadata?.scopes_supported).toContain('organizations:read')
+      expect(metadata?.scopes_supported).toContain('database:write')
+    })
+  })
+
+  describe('getAuthorizationServerUrl', () => {
+    it('should return first authorization server from metadata', () => {
+      const metadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com',
+        authorization_servers: ['https://auth1.example.com', 'https://auth2.example.com'],
+      }
+
+      const url = getAuthorizationServerUrl(metadata)
+
+      expect(url).toBe('https://auth1.example.com')
+    })
+
+    it('should return undefined if authorization_servers is empty', () => {
+      const metadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com',
+        authorization_servers: [],
+      }
+
+      const url = getAuthorizationServerUrl(metadata)
+
+      expect(url).toBeUndefined()
+    })
+
+    it('should return undefined if authorization_servers is missing', () => {
+      const metadata: ProtectedResourceMetadata = {
+        resource: 'https://mcp.example.com',
+      }
+
+      const url = getAuthorizationServerUrl(metadata)
+
+      expect(url).toBeUndefined()
+    })
+  })
+})

--- a/src/lib/protected-resource-metadata.ts
+++ b/src/lib/protected-resource-metadata.ts
@@ -1,0 +1,231 @@
+import { debugLog } from './utils'
+
+/**
+ * OAuth 2.0 Protected Resource Metadata as defined in RFC 9728
+ * https://datatracker.ietf.org/doc/html/rfc9728
+ */
+export interface ProtectedResourceMetadata {
+  /** The protected resource's resource identifier */
+  resource: string
+  /** JSON array containing a list of OAuth authorization server issuer identifiers */
+  authorization_servers?: string[]
+  /** JSON array containing a list of OAuth 2.0 scope values that are used in authorization requests */
+  scopes_supported?: string[]
+  /** JSON array containing a list of methods supported to present bearer tokens */
+  bearer_methods_supported?: string[]
+  /** JSON array containing JWS signing algorithms supported for resource request signing */
+  resource_signing_alg_values_supported?: string[]
+  /** URL of a page containing human-readable information about the protected resource */
+  resource_documentation?: string
+  /** Human-readable name of the protected resource */
+  resource_name?: string
+  /** Additional metadata fields */
+  [key: string]: unknown
+}
+
+/**
+ * Result of parsing a WWW-Authenticate header
+ */
+export interface WWWAuthenticateParams {
+  /** The resource_metadata URL if present */
+  resourceMetadataUrl?: string
+  /** The scope parameter if present */
+  scope?: string
+  /** The error parameter if present */
+  error?: string
+  /** The error_description parameter if present */
+  errorDescription?: string
+}
+
+/**
+ * Parses a WWW-Authenticate header to extract resource_metadata URL and other parameters
+ *
+ * Example header:
+ * Bearer error="invalid_request", error_description="No access token", resource_metadata="https://example.com/.well-known/oauth-protected-resource"
+ *
+ * @param header The WWW-Authenticate header value
+ * @returns Parsed parameters including resource_metadata URL and scope
+ */
+export function parseWWWAuthenticateHeader(header: string): WWWAuthenticateParams {
+  const result: WWWAuthenticateParams = {}
+
+  if (!header) {
+    return result
+  }
+
+  // Remove "Bearer " prefix if present (case-insensitive)
+  const paramString = header.replace(/^Bearer\s+/i, '')
+
+  // Parse key="value" pairs, handling quoted strings properly
+  // This regex matches: key="value" or key=value
+  const paramRegex = /(\w+)=(?:"([^"]*)"|([\w-]+))/g
+  let match
+
+  while ((match = paramRegex.exec(paramString)) !== null) {
+    const key = match[1]
+    const value = match[2] ?? match[3] // Use quoted value if present, otherwise unquoted
+
+    switch (key) {
+      case 'resource_metadata':
+        result.resourceMetadataUrl = value
+        break
+      case 'scope':
+        result.scope = value
+        break
+      case 'error':
+        result.error = value
+        break
+      case 'error_description':
+        result.errorDescription = value
+        break
+    }
+  }
+
+  debugLog('Parsed WWW-Authenticate header', {
+    hasResourceMetadata: !!result.resourceMetadataUrl,
+    hasScope: !!result.scope,
+    error: result.error,
+  })
+
+  return result
+}
+
+/**
+ * Builds the well-known URLs for Protected Resource Metadata discovery
+ *
+ * Per RFC 9728, clients should try:
+ * 1. Path-specific: /.well-known/oauth-protected-resource/[path]
+ * 2. Root-level: /.well-known/oauth-protected-resource
+ *
+ * @param resourceUrl The URL of the protected resource (MCP server)
+ * @returns Array of URLs to try in order
+ */
+export function buildProtectedResourceMetadataUrls(resourceUrl: string): string[] {
+  const url = new URL(resourceUrl)
+  const urls: string[] = []
+
+  // Get the path without trailing slash
+  const path = url.pathname.replace(/\/$/, '')
+
+  // 1. Path-specific well-known URL (if there's a path)
+  if (path && path !== '/') {
+    urls.push(`${url.origin}/.well-known/oauth-protected-resource${path}`)
+  }
+
+  // 2. Root-level well-known URL
+  urls.push(`${url.origin}/.well-known/oauth-protected-resource`)
+
+  debugLog('Built Protected Resource Metadata URLs', { resourceUrl, urls })
+
+  return urls
+}
+
+/**
+ * Fetches Protected Resource Metadata from a specific URL
+ *
+ * @param metadataUrl The URL to fetch metadata from
+ * @returns The metadata if successful, undefined otherwise
+ */
+async function fetchProtectedResourceMetadataFromUrl(metadataUrl: string): Promise<ProtectedResourceMetadata | undefined> {
+  debugLog('Fetching Protected Resource Metadata', { metadataUrl })
+
+  try {
+    const response = await fetch(metadataUrl, {
+      headers: {
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        debugLog('Protected Resource Metadata not found (404)', { metadataUrl })
+      } else {
+        debugLog('Failed to fetch Protected Resource Metadata', {
+          status: response.status,
+          statusText: response.statusText,
+        })
+      }
+      return undefined
+    }
+
+    const metadata = (await response.json()) as ProtectedResourceMetadata
+
+    debugLog('Successfully fetched Protected Resource Metadata', {
+      resource: metadata.resource,
+      authorizationServers: metadata.authorization_servers,
+      scopesSupported: metadata.scopes_supported,
+    })
+
+    return metadata
+  } catch (error) {
+    debugLog('Error fetching Protected Resource Metadata', {
+      error: error instanceof Error ? error.message : String(error),
+      metadataUrl,
+    })
+    return undefined
+  }
+}
+
+/**
+ * Discovers Protected Resource Metadata for a given resource URL
+ *
+ * This implements the full discovery flow per RFC 9728 and MCP spec:
+ * 1. If WWW-Authenticate header is provided with resource_metadata, use that URL directly
+ * 2. Otherwise, try the path-specific well-known URL
+ * 3. If that fails, try the root well-known URL
+ *
+ * @param resourceUrl The URL of the protected resource (MCP server)
+ * @param wwwAuthenticateHeader Optional WWW-Authenticate header from a 401 response
+ * @returns The metadata if found, undefined otherwise
+ */
+export async function discoverProtectedResourceMetadata(
+  resourceUrl: string,
+  wwwAuthenticateHeader?: string,
+): Promise<ProtectedResourceMetadata | undefined> {
+  debugLog('Starting Protected Resource Metadata discovery', {
+    resourceUrl,
+    hasWWWAuthenticateHeader: !!wwwAuthenticateHeader,
+  })
+
+  // Priority 1: Check WWW-Authenticate header for resource_metadata URL
+  if (wwwAuthenticateHeader) {
+    const params = parseWWWAuthenticateHeader(wwwAuthenticateHeader)
+    if (params.resourceMetadataUrl) {
+      debugLog('Using resource_metadata URL from WWW-Authenticate header', {
+        url: params.resourceMetadataUrl,
+      })
+      const metadata = await fetchProtectedResourceMetadataFromUrl(params.resourceMetadataUrl)
+      if (metadata) {
+        return metadata
+      }
+      // If the URL from the header fails, fall through to well-known discovery
+      debugLog('Failed to fetch from WWW-Authenticate URL, falling back to well-known discovery')
+    }
+  }
+
+  // Priority 2 & 3: Try well-known URLs in order
+  const wellKnownUrls = buildProtectedResourceMetadataUrls(resourceUrl)
+  for (const url of wellKnownUrls) {
+    const metadata = await fetchProtectedResourceMetadataFromUrl(url)
+    if (metadata) {
+      return metadata
+    }
+  }
+
+  debugLog('Protected Resource Metadata discovery failed - no metadata found')
+  return undefined
+}
+
+/**
+ * Extracts the authorization server URL from Protected Resource Metadata
+ *
+ * @param metadata The Protected Resource Metadata
+ * @returns The first authorization server URL, or undefined if none
+ */
+export function getAuthorizationServerUrl(metadata: ProtectedResourceMetadata): string | undefined {
+  if (metadata.authorization_servers && metadata.authorization_servers.length > 0) {
+    return metadata.authorization_servers[0]
+  }
+  return undefined
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { OAuthClientInformationFull, OAuthClientMetadata } from '@modelcontextprotocol/sdk/shared/auth.js'
 import type { AuthorizationServerMetadata } from './authorization-server-metadata'
+import type { ProtectedResourceMetadata } from './protected-resource-metadata'
 
 /**
  * Options for creating an OAuth client provider
@@ -34,6 +35,10 @@ export interface OAuthProviderOptions {
   serverUrlHash: string
   /** Authorization server metadata (optional, fetched if not provided) */
   authorizationServerMetadata?: AuthorizationServerMetadata
+  /** Protected resource metadata (optional, discovered from 401 response) */
+  protectedResourceMetadata?: ProtectedResourceMetadata
+  /** Scope extracted from WWW-Authenticate header */
+  wwwAuthenticateScope?: string
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,11 +11,19 @@
 
 import { EventEmitter } from 'events'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { connectToRemoteServer, log, debugLog, mcpProxy, parseCommandLineArgs, setupSignalHandlers, TransportStrategy } from './lib/utils'
+import {
+  connectToRemoteServer,
+  log,
+  debugLog,
+  mcpProxy,
+  parseCommandLineArgs,
+  setupSignalHandlers,
+  TransportStrategy,
+  discoverOAuthServerInfo,
+} from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator } from './lib/coordination'
-import { fetchAuthorizationServerMetadata } from './lib/authorization-server-metadata'
 
 /**
  * Main function to run the proxy
@@ -39,22 +47,25 @@ async function runProxy(
   // Create a lazy auth coordinator
   const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
 
-  // Pre-fetch authorization server metadata for scope validation
-  let authorizationServerMetadata
-  try {
-    authorizationServerMetadata = await fetchAuthorizationServerMetadata(serverUrl)
-    if (authorizationServerMetadata?.scopes_supported) {
-      debugLog('Pre-fetched authorization server metadata', {
-        scopes_supported: authorizationServerMetadata.scopes_supported,
+  // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
+  // This probes the MCP server for WWW-Authenticate header and fetches PRM
+  log('Discovering OAuth server configuration...')
+  const discoveryResult = await discoverOAuthServerInfo(serverUrl, headers)
+
+  if (discoveryResult.protectedResourceMetadata) {
+    log(`Discovered authorization server: ${discoveryResult.authorizationServerUrl}`)
+    if (discoveryResult.protectedResourceMetadata.scopes_supported) {
+      debugLog('Protected Resource Metadata scopes', {
+        scopes_supported: discoveryResult.protectedResourceMetadata.scopes_supported,
       })
     }
-  } catch (error) {
-    debugLog('Failed to pre-fetch authorization server metadata', error)
+  } else {
+    debugLog('No Protected Resource Metadata found, using server URL as authorization server')
   }
 
-  // Create the OAuth client provider
+  // Create the OAuth client provider with discovered server info
   const authProvider = new NodeOAuthClientProvider({
-    serverUrl,
+    serverUrl: discoveryResult.authorizationServerUrl,
     callbackPort,
     host,
     clientName: 'MCP CLI Proxy',
@@ -62,7 +73,9 @@ async function runProxy(
     staticOAuthClientInfo,
     authorizeResource,
     serverUrlHash,
-    authorizationServerMetadata,
+    authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
+    protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
+    wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
   })
 
   // Create the STDIO transport for local connections


### PR DESCRIPTION
## Summary

This PR adds support for OAuth 2.0 Protected Resource Metadata discovery (RFC 9728) to properly discover authorization servers that are hosted on different domains than the MCP server. This is required for MCP Authorization Server Discovery compliance and enables interoperability with MCP servers like Supabase where the auth server (`https://api.supabase.com`) differs from the MCP server (`https://mcp.supabase.com`).

## Problem

Previously, `mcp-remote` assumed the MCP server URL was the same as the authorization server URL. This broke authentication for servers like Supabase that return:

```http
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer error="invalid_request",
                         error_description="No access token was provided in this request",
                         resource_metadata="https://mcp.supabase.com/.well-known/oauth-protected-resource/mcp"
```

## Changes

### New Module: Protected Resource Metadata

- Created `protected-resource-metadata.ts` module implementing RFC 9728
- `parseWWWAuthenticateHeader()` - Extracts `resource_metadata`, `scope`, `error`, and `error_description` from 401 responses
- `buildProtectedResourceMetadataUrls()` - Constructs well-known URLs with proper fallback order
- `discoverProtectedResourceMetadata()` - Full discovery flow with header priority, then path-specific, then root well-known
- `getAuthorizationServerUrl()` - Extracts first authorization server from metadata
- Comprehensive test coverage (24 tests) including Supabase-specific scenarios

### OAuth Server Discovery Flow

- Added `discoverOAuthServerInfo()` function in `utils.ts` implementing the MCP spec discovery flow:
  1. Probe MCP server to get `WWW-Authenticate` header
  2. Parse `resource_metadata` URL from header (if present)
  3. Fetch Protected Resource Metadata from header URL or well-known endpoints
  4. Extract `authorization_servers` to find the actual OAuth server
  5. Fetch Authorization Server Metadata from discovered server

### Enhanced Scope Resolution

Updated `NodeOAuthClientProvider` with new scope priority order:
1. User-provided scope from static OAuth client metadata (highest)
2. Scope from `WWW-Authenticate` header (new!)
3. `scopes_supported` from Protected Resource Metadata (new!)
4. Scope from client registration response
5. `scopes_supported` from Authorization Server Metadata
6. Fallback default (`openid email profile`)

### Client & Proxy Integration

- Both `client.ts` and `proxy.ts` now call `discoverOAuthServerInfo()` on startup
- Pass discovered authorization server URL to `NodeOAuthClientProvider`
- Pass Protected Resource Metadata and WWW-Authenticate scope for proper scope resolution
- Added debug logging throughout the discovery flow
- Graceful fallback to previous behavior if discovery fails

## Benefits

- **Supabase compatibility**: Now works correctly with Supabase MCP server and similar setups
- **RFC 9728 compliance**: Implements Protected Resource Metadata discovery per spec
- **MCP spec compliance**: Follows MCP Authorization Server Discovery requirements
- **Automatic scope discovery**: Uses `scopes_supported` from PRM for proper authorization
- **Graceful degradation**: Falls back to server URL if no PRM is found
- **Backwards compatible**: Existing setups continue to work unchanged

## Testing

- Added 24 new unit tests for Protected Resource Metadata discovery
- Tests cover WWW-Authenticate parsing, well-known URL construction, discovery fallbacks, and Supabase-specific scenarios
- All 100 tests pass (76 existing + 24 new)

### Test with Supabase MCP Server

```bash
npm run build
node dist/proxy.js https://mcp.supabase.com/mcp --debug
```

Closes #192 
