### PR TITLE
Make auth storage version-agnostic by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,90 +301,9 @@ Know of more resources you'd like to share? Please add them to this Readme and s
 
 ## Troubleshooting
 
-### Clear your `~/.mcp-auth` directory
+See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for solutions to common issues including:
 
-`mcp-remote` stores all the credential information inside `~/.mcp-auth` (or wherever your `MCP_REMOTE_CONFIG_DIR` points to). If you're having persistent issues, try running:
-
-```sh
-rm -rf ~/.mcp-auth
-```
-
-Then restarting your MCP client.
-
-### Check your Node version
-
-Make sure that the version of Node you have installed is [18 or
-higher](https://modelcontextprotocol.io/quickstart/server). Claude
-Desktop will use your system version of Node, even if you have a newer
-version installed elsewhere.
-
-### Restart Claude
-
-When modifying `claude_desktop_config.json` it can helpful to completely restart Claude
-
-### VPN Certs
-
-You may run into issues if you are behind a VPN, you can try setting the `NODE_EXTRA_CA_CERTS`
-environment variable to point to the CA certificate file. If using `claude_desktop_config.json`,
-this might look like:
-
-```json
-{
- "mcpServers": {
-    "remote-example": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://remote.mcp.server/sse"
-      ],
-      "env": {
-        "NODE_EXTRA_CA_CERTS": "{your CA certificate file path}.pem"
-      }
-    }
-  }
-}
-```
-
-### Check the logs
-
-* [Follow Claude Desktop logs in real-time](https://modelcontextprotocol.io/docs/tools/debugging#debugging-in-claude-desktop)
-* MacOS / Linux:<br/>`tail -n 20 -F ~/Library/Logs/Claude/mcp*.log`
-* For bash on WSL:<br/>`tail -n 20 -f "C:\Users\YourUsername\AppData\Local\Claude\Logs\mcp.log"`
-* Powershell: <br/>`Get-Content "C:\Users\YourUsername\AppData\Local\Claude\Logs\mcp.log" -Wait -Tail 20`
-
-## Debugging
-
-### Debug Logs
-
-For troubleshooting complex issues, especially with token refreshing or authentication problems, use the `--debug` flag:
-
-```json
-"args": [
-  "mcp-remote",
-  "https://remote.mcp.server/sse",
-  "--debug"
-]
-```
-
-This creates detailed logs in `~/.mcp-auth/{server_hash}_debug.log` with timestamps and complete information about every step of the connection and authentication process. When you find issues with token refreshing, laptop sleep/resume issues, or auth problems, provide these logs when seeking support.
-
-### Authentication Errors
-
-If you encounter the following error, returned by the `/callback` URL:
-
-```
-Authentication Error
-Token exchange failed: HTTP 400
-```
-
-You can run `rm -rf ~/.mcp-auth` to clear any locally stored state and tokens.
-
-### "Client" mode
-
-Run the following on the command line (not from an MCP server):
-
-```shell
-npx -p mcp-remote@latest mcp-remote-client https://remote.mcp.server/sse
-```
-
-This will run through the entire authorization flow and attempt to list the tools & resources at the remote URL. Try this after running `rm -rf ~/.mcp-auth` to see if stale credentials are your problem, otherwise hopefully the issue will be more obvious in these logs than those in your MCP client.
+- Auth storage and credential management
+- Node version requirements
+- VPN and certificate issues
+- Debug logging

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,94 @@
+# Troubleshooting
+
+## Auth Storage
+
+Credentials are stored in `~/.mcp-auth/mcp-remote/` (or `{MCP_REMOTE_CONFIG_DIR}/mcp-remote/` if set).
+
+**Version-agnostic storage (default):** Tokens persist across mcp-remote updates. No re-authentication needed when the package updates.
+
+**Version-specific storage:** Set `MCP_REMOTE_VERSIONED_CONFIG=1` to use version-specific directories like `~/.mcp-auth/mcp-remote-0.1.31/` (useful for development/testing).
+
+### Clearing Credentials
+
+If you're having persistent auth issues, try clearing stored credentials:
+
+```sh
+rm -rf ~/.mcp-auth/mcp-remote
+```
+
+Then restart your MCP client.
+
+## Check your Node version
+
+Make sure that the version of Node you have installed is [18 or
+higher](https://modelcontextprotocol.io/quickstart/server). Claude
+Desktop will use your system version of Node, even if you have a newer
+version installed elsewhere.
+
+## Restart Claude
+
+When modifying `claude_desktop_config.json` it can helpful to completely restart Claude.
+
+## VPN Certs
+
+You may run into issues if you are behind a VPN, you can try setting the `NODE_EXTRA_CA_CERTS`
+environment variable to point to the CA certificate file. If using `claude_desktop_config.json`,
+this might look like:
+
+```json
+{
+  "mcpServers": {
+    "remote-example": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://remote.mcp.server/sse"],
+      "env": {
+        "NODE_EXTRA_CA_CERTS": "{your CA certificate file path}.pem"
+      }
+    }
+  }
+}
+```
+
+## Check the logs
+
+- [Follow Claude Desktop logs in real-time](https://modelcontextprotocol.io/docs/tools/debugging#debugging-in-claude-desktop)
+- MacOS / Linux:<br/>`tail -n 20 -F ~/Library/Logs/Claude/mcp*.log`
+- For bash on WSL:<br/>`tail -n 20 -f "C:\Users\YourUsername\AppData\Local\Claude\Logs\mcp.log"`
+- Powershell: <br/>`Get-Content "C:\Users\YourUsername\AppData\Local\Claude\Logs\mcp.log" -Wait -Tail 20`
+
+# Debugging
+
+## Debug Logs
+
+For troubleshooting complex issues, especially with token refreshing or authentication problems, use the `--debug` flag:
+
+```json
+"args": [
+  "mcp-remote",
+  "https://remote.mcp.server/sse",
+  "--debug"
+]
+```
+
+This creates detailed logs in `~/.mcp-auth/{server_hash}_debug.log` with timestamps and complete information about every step of the connection and authentication process. When you find issues with token refreshing, laptop sleep/resume issues, or auth problems, provide these logs when seeking support.
+
+## Authentication Errors
+
+If you encounter the following error, returned by the `/callback` URL:
+
+```
+Authentication Error
+Token exchange failed: HTTP 400
+```
+
+You can run `rm -rf ~/.mcp-auth` to clear any locally stored state and tokens.
+
+## "Client" mode
+
+Run the following on the command line (not from an MCP server):
+
+```shell
+npx -p mcp-remote@latest mcp-remote-client https://remote.mcp.server/sse
+```
+
+This will run through the entire authorization flow and attempt to list the tools & resources at the remote URL. Try this after running `rm -rf ~/.mcp-auth` to see if stale credentials are your problem, otherwise hopefully the issue will be more obvious in these logs than those in your MCP client.

--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+// We need to mock the module before importing getConfigDir
+// Store original env
+const originalEnv = { ...process.env }
+
+describe('Feature: Config Directory Path Resolution', () => {
+  beforeEach(() => {
+    // Reset modules to ensure fresh imports with new env values
+    vi.resetModules()
+    // Reset env to original state
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('Scenario: Returns mcp-remote subdirectory by default (version-agnostic)', async () => {
+    // Given no environment variables are set for versioned config
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    delete process.env.MCP_REMOTE_VERSIONED_CONFIG
+
+    // When getting the config directory
+    const { getConfigDir } = await import('./mcp-auth-config')
+    const result = getConfigDir()
+
+    // Then it should return the mcp-remote subdirectory (namespaced but version-agnostic)
+    expect(result).toBe(path.join(os.homedir(), '.mcp-auth', 'mcp-remote'))
+  })
+
+  it('Scenario: Returns versioned directory when MCP_REMOTE_VERSIONED_CONFIG=1', async () => {
+    // Given MCP_REMOTE_VERSIONED_CONFIG is set to 1
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    process.env.MCP_REMOTE_VERSIONED_CONFIG = '1'
+
+    // When getting the config directory
+    const { getConfigDir } = await import('./mcp-auth-config')
+    const result = getConfigDir()
+
+    // Then it should return a version-specific directory
+    expect(result).toMatch(/\.mcp-auth[/\\]mcp-remote-\d+\.\d+\.\d+/)
+  })
+
+  it('Scenario: Respects MCP_REMOTE_CONFIG_DIR with mcp-remote subdirectory', async () => {
+    // Given a custom config directory is set
+    process.env.MCP_REMOTE_CONFIG_DIR = '/custom/path'
+    delete process.env.MCP_REMOTE_VERSIONED_CONFIG
+
+    // When getting the config directory
+    const { getConfigDir } = await import('./mcp-auth-config')
+    const result = getConfigDir()
+
+    // Then it should return the custom path with mcp-remote subdirectory
+    expect(result).toBe(path.join('/custom/path', 'mcp-remote'))
+  })
+
+  it('Scenario: Combines custom dir with versioned config', async () => {
+    // Given both custom config dir and versioned config are set
+    process.env.MCP_REMOTE_CONFIG_DIR = '/custom/path'
+    process.env.MCP_REMOTE_VERSIONED_CONFIG = '1'
+
+    // When getting the config directory
+    const { getConfigDir } = await import('./mcp-auth-config')
+    const result = getConfigDir()
+
+    // Then it should return the custom path with version suffix
+    expect(result).toMatch(/[/\\]custom[/\\]path[/\\]mcp-remote-\d+\.\d+\.\d+/)
+  })
+
+  it('Scenario: MCP_REMOTE_VERSIONED_CONFIG with value other than 1 is ignored', async () => {
+    // Given MCP_REMOTE_VERSIONED_CONFIG is set to something other than '1'
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    process.env.MCP_REMOTE_VERSIONED_CONFIG = 'true'
+
+    // When getting the config directory
+    const { getConfigDir } = await import('./mcp-auth-config')
+    const result = getConfigDir()
+
+    // Then it should return the mcp-remote subdirectory (version-agnostic default)
+    expect(result).toBe(path.join(os.homedir(), '.mcp-auth', 'mcp-remote'))
+  })
+})


### PR DESCRIPTION
## Summary
- Credentials are now stored in a version-agnostic `mcp-remote/` subdirectory instead of `mcp-remote-{version}/`
- Auto-migrates existing credentials from version-specific directories on first run
- Adds `MCP_REMOTE_CONFIG_VERSION` env var to opt back into version-specific storage if needed
- Adds TROUBLESHOOTING.md with migration guidance

## Problem
Every mcp-remote version bump created a new config directory, requiring users to re-authenticate with all their MCP servers.

## Solution
Store credentials in a shared directory by default, with backward-compatible migration.

## Test plan
- [x] Unit tests added for config directory resolution
- [x] Unit tests added for migration logic
- [x] Existing tests pass (`npm run test:unit`)
- [x] Manual testing with version upgrade scenario