### PR TITLE
Add --callback-path CLI flag for OAuth redirect URI customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mcp-remote",
-  "version": "0.1.38",
+  "name": "@ravshansbox/mcp-remote",
+  "version": "0.1.38-1",
   "description": "Remote proxy for Model Context Protocol, allowing local-only clients to connect to remote servers using oAuth",
   "keywords": [
     "mcp",

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,12 +39,13 @@ async function runClient(
   staticOAuthClientInfo: StaticOAuthClientInformationFull,
   authTimeoutMs: number,
   serverUrlHash: string,
+  callbackPath?: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -67,13 +68,14 @@ async function runClient(
     serverUrl: discoveryResult.authorizationServerUrl,
     callbackPort,
     host,
-    clientName: 'MCP CLI Client',
+    clientName: 'Codex',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
     serverUrlHash,
     authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
     protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
     wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
+    callbackPath,
   })
 
   // Create the client
@@ -190,6 +192,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
       staticOAuthClientInfo,
       authTimeoutMs,
       serverUrlHash,
+      callbackPath,
     }) => {
       return runClient(
         serverUrl,
@@ -201,6 +204,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
         staticOAuthClientInfo,
         authTimeoutMs,
         serverUrlHash,
+        callbackPath,
       )
     },
   )

--- a/src/client.ts
+++ b/src/client.ts
@@ -45,7 +45,7 @@ async function runClient(
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath, host)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM

--- a/src/client.ts
+++ b/src/client.ts
@@ -68,7 +68,7 @@ async function runClient(
     serverUrl: discoveryResult.authorizationServerUrl,
     callbackPort,
     host,
-    clientName: 'Codex',
+    clientName: 'MCP CLI Client',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
     serverUrlHash,

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -133,6 +133,7 @@ export function createLazyAuthCoordinator(
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  callbackPath?: string,
 ): AuthCoordinator {
   let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean } | null = null
 
@@ -145,10 +146,10 @@ export function createLazyAuthCoordinator(
       }
 
       log('Initializing auth coordination on-demand')
-      debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
+      debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort, callbackPath })
 
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs)
+      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath)
       debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
       return authState
     },
@@ -167,6 +168,7 @@ export async function coordinateAuth(
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  callbackPath?: string,
 ): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPort })
 
@@ -226,10 +228,10 @@ export async function coordinateAuth(
   }
 
   // Create our own lockfile
-  debugLog('Setting up OAuth callback server', { port: callbackPort })
+  debugLog('Setting up OAuth callback server', { port: callbackPort, path: callbackPath || '/oauth/callback' })
   const { server, waitForAuthCode, authCompletedPromise } = setupOAuthCallbackServerWithLongPoll({
     port: callbackPort,
-    path: '/oauth/callback',
+    path: callbackPath || '/oauth/callback',
     events,
     authTimeoutMs,
   })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,8 @@ export interface OAuthCallbackServerOptions {
   port: number
   /** Path for the callback endpoint */
   path: string
+  /** Host for the callback server (defaults to 127.0.0.1 for security) */
+  host?: string
   /** Event emitter to signal when auth code is received */
   events: EventEmitter
   /** Timeout in milliseconds for the auth callback server's long poll */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -645,8 +645,8 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     options.events.emit('auth-code-received', code)
   })
 
-  const server = app.listen(options.port, '127.0.0.1', () => {
-    log(`OAuth callback server running at http://127.0.0.1:${options.port}`)
+  const server = app.listen(options.port, () => {
+    log(`OAuth callback server running at http://localhost:${options.port}`)
   })
 
   const waitForAuthCode = (): Promise<string> => {
@@ -800,6 +800,14 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     log(`Using callback hostname: ${host}`)
   }
 
+  // Parse callback path
+  let callbackPath: string | undefined = undefined
+  const callbackPathIndex = args.indexOf('--callback-path')
+  if (callbackPathIndex !== -1 && callbackPathIndex < args.length - 1) {
+    callbackPath = args[callbackPathIndex + 1]
+    log(`Using callback path: ${callbackPath}`)
+  }
+
   let staticOAuthClientMetadata: StaticOAuthClientMetadata = null
   const staticOAuthClientMetadataIndex = args.indexOf('--static-oauth-client-metadata')
   if (staticOAuthClientMetadataIndex !== -1 && staticOAuthClientMetadataIndex < args.length - 1) {
@@ -942,6 +950,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     ignoredTools,
     authTimeoutMs,
     serverUrlHash,
+    callbackPath,
   }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -645,8 +645,8 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     options.events.emit('auth-code-received', code)
   })
 
-  const server = app.listen(options.port, () => {
-    log(`OAuth callback server running at http://localhost:${options.port}`)
+  const server = app.listen(options.port, options.host || '127.0.0.1', () => {
+    log(`OAuth callback server running at http://${options.host || '127.0.0.1'}:${options.port}`)
   })
 
   const waitForAuthCode = (): Promise<string> => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -40,12 +40,13 @@ async function runProxy(
   ignoredTools: string[],
   authTimeoutMs: number,
   serverUrlHash: string,
+  callbackPath?: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -68,7 +69,7 @@ async function runProxy(
     serverUrl: discoveryResult.authorizationServerUrl,
     callbackPort,
     host,
-    clientName: 'MCP CLI Proxy',
+    clientName: 'Codex',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
     authorizeResource,
@@ -76,6 +77,7 @@ async function runProxy(
     authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
     protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
     wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
+    callbackPath,
   })
 
   // Create the STDIO transport for local connections
@@ -180,6 +182,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       ignoredTools,
       authTimeoutMs,
       serverUrlHash,
+      callbackPath,
     }) => {
       return runProxy(
         serverUrl,
@@ -193,6 +196,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
         ignoredTools,
         authTimeoutMs,
         serverUrlHash,
+        callbackPath,
       )
     },
   )

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -69,7 +69,7 @@ async function runProxy(
     serverUrl: discoveryResult.authorizationServerUrl,
     callbackPort,
     host,
-    clientName: 'Codex',
+    clientName: 'MCP CLI Proxy',
     staticOAuthClientMetadata,
     staticOAuthClientInfo,
     authorizeResource,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,7 @@ async function runProxy(
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackPath, host)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM


### PR DESCRIPTION
## Summary
Adds a `--callback-path` CLI flag to allow customization of the OAuth callback path, which is needed for MCP servers with restrictive OAuth allowlists (e.g., Figma MCP).

## Changes
- Added `--callback-path` CLI flag in `src/lib/utils.ts`
- Updated `src/lib/coordination.ts` to pass callback path to OAuth callback server
- Updated `src/proxy.ts` and `src/client.ts` to accept and use the new flag

## Use Case: Figma MCP
Figma MCP has an OAuth allowlist that only allows certain client names (like "Codex"). To use mcp-remote with Figma MCP, users need to:

1. Override client name to "Codex" (using `--static-oauth-client-metadata`)
2. Use the matching callback path `/callback` instead of `/oauth/callback`

## Example Usage
```bash
mcp-remote https://mcp.figma.com/mcp 9696 \
  --callback-path /callback \
  --static-oauth-client-metadata '{"client_name":"Codex","redirect_uris":["http://localhost:9696/callback"]}'
```

## Related Issue
Fixes #232