### PR TITLE
feat: add --callback-html flag to override OAuth callback page

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ You can specify multiple `--ignore-tool` flags to ignore different patterns. Exa
       ]
 ```
 
+* To override the HTML rendered on the OAuth callback page, add the `--callback-html` flag with either an inline HTML string or a `@`-prefixed filepath. See [Custom Callback Page](#custom-callback-page) for details.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--callback-html",
+        "@/Users/username/.config/mcp-remote/callback.html"
+      ]
+```
+
 ### Transport Strategies
 
 MCP Remote supports different transport strategies when connecting to an MCP server. This allows you to control whether it uses Server-Sent Events (SSE) or HTTP transport, and in what order it tries them.
@@ -266,6 +277,32 @@ npx mcp-remote https://example.remote/server --static-oauth-client-info "{ \"cli
 # uses node readfile, so you probably want to use absolute paths if you're not sure what the cwd is
 npx mcp-remote https://example.remote/server --static-oauth-client-info '@/Users/username/Library/Application Support/Claude/oauth_client_info.json'
 ```
+
+### Custom Callback Page
+
+After the OAuth code exchange completes, mcp-remote serves a small HTML page on
+the loopback callback URL. By default that page reads "Authorization
+successful! You may close this window and return to the CLI." with a
+`window.close()` script that only fires if the host browser opened the tab via
+`window.open` (so for OS-launched browsers the user is left looking at the
+default text).
+
+The `--callback-html` flag overrides that page. Pass either an inline HTML
+string or a `@`-prefixed filepath:
+
+```bash
+# Inline (silent auto-close attempt, no visible text)
+npx mcp-remote https://example.remote/server \
+  --callback-html '<!doctype html><title>Signed in</title><script>window.close()</script>'
+
+# From a file
+npx mcp-remote https://example.remote/server \
+  --callback-html '@/Users/username/.config/mcp-remote/callback.html'
+```
+
+This is purely cosmetic — the callback handler still receives the auth code
+and resolves the OAuth flow exactly as before; the supplied HTML is simply
+what the user's browser sees on the loopback page.
 
 ### Claude Desktop
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,13 +38,14 @@ async function runClient(
   staticOAuthClientMetadata: StaticOAuthClientMetadata,
   staticOAuthClientInfo: StaticOAuthClientInformationFull,
   authTimeoutMs: number,
+  callbackHtml: string | undefined,
   serverUrlHash: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackHtml)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -189,6 +190,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
       staticOAuthClientMetadata,
       staticOAuthClientInfo,
       authTimeoutMs,
+      callbackHtml,
       serverUrlHash,
     }) => {
       return runClient(
@@ -200,6 +202,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
         staticOAuthClientMetadata,
         staticOAuthClientInfo,
         authTimeoutMs,
+        callbackHtml,
         serverUrlHash,
       )
     },

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -133,6 +133,7 @@ export function createLazyAuthCoordinator(
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  callbackHtml?: string,
 ): AuthCoordinator {
   let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean } | null = null
 
@@ -148,7 +149,7 @@ export function createLazyAuthCoordinator(
       debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
 
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs)
+      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs, callbackHtml)
       debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
       return authState
     },
@@ -167,6 +168,7 @@ export async function coordinateAuth(
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  callbackHtml?: string,
 ): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPort })
 
@@ -232,6 +234,7 @@ export async function coordinateAuth(
     path: '/oauth/callback',
     events,
     authTimeoutMs,
+    callbackHtml,
   })
 
   // Get the actual port the server is running on

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,13 @@ export interface OAuthCallbackServerOptions {
   events: EventEmitter
   /** Timeout in milliseconds for the auth callback server's long poll */
   authTimeoutMs?: number
+  /**
+   * HTML body to render on the OAuth callback page after a successful code
+   * exchange. When omitted, the default "Authorization successful! ..."
+   * message is shown. Hosts that spawn mcp-remote programmatically (or users
+   * who want a quieter landing page) can supply their own markup.
+   */
+  callbackHtml?: string
 }
 
 // optional tatic OAuth client information

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -325,6 +325,36 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(result.ignoredTools).toEqual(['tool1', 'tool2'])
   })
 
+  it('Scenario: callbackHtml is undefined when --callback-html is not specified', async () => {
+    const args = ['https://example.com/sse']
+    const result = await parseCommandLineArgs(args, 'test usage')
+    expect(result.callbackHtml).toBeUndefined()
+  })
+
+  it('Scenario: Parse inline --callback-html string', async () => {
+    const inline = '<title>Quiet</title><script>window.close()</script>'
+    const args = ['https://example.com/sse', '--callback-html', inline]
+    const result = await parseCommandLineArgs(args, 'test usage')
+    expect(result.callbackHtml).toBe(inline)
+  })
+
+  it('Scenario: Parse --callback-html @file path and read file contents', async () => {
+    const fs = await import('fs/promises')
+    const os = await import('os')
+    const path = await import('path')
+    const tmp = path.join(os.tmpdir(), `mcp-remote-cb-${Date.now()}.html`)
+    const fileBody = '<!doctype html><title>From file</title>'
+    await fs.writeFile(tmp, fileBody, 'utf8')
+
+    try {
+      const args = ['https://example.com/sse', '--callback-html', `@${tmp}`]
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.callbackHtml).toBe(fileBody)
+    } finally {
+      await fs.rm(tmp, { force: true })
+    }
+  })
+
   it('Scenario: Use default auth timeout when not specified', async () => {
     // Given command line arguments without --auth-timeout flag
     const args = ['https://example.com/sse']
@@ -1024,6 +1054,44 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     // Test that the server was created with defaults
     expect(server).toBeDefined()
     expect(typeof result.waitForAuthCode).toBe('function')
+  })
+
+  it('should render the default success page when callbackHtml is not provided', async () => {
+    const result = setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events,
+    })
+    server = result.server
+
+    await new Promise<void>((resolve) => server.once('listening', resolve))
+    const port = server.address().port
+    const response = await fetch(`http://127.0.0.1:${port}/oauth/callback?code=test-code`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Authorization successful!')
+    expect(body).toContain('window.close()')
+  })
+
+  it('should render the supplied HTML when callbackHtml is provided', async () => {
+    const customHtml = '<!doctype html><title>Quiet</title><script>window.close();</script>'
+    const result = setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events,
+      callbackHtml: customHtml,
+    })
+    server = result.server
+
+    await new Promise<void>((resolve) => server.once('listening', resolve))
+    const port = server.address().port
+    const response = await fetch(`http://127.0.0.1:${port}/oauth/callback?code=test-code`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toBe(customHtml)
+    expect(body).not.toContain('Authorization successful!')
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -630,7 +630,9 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     log('Auth code received, resolving promise')
     authCompletedResolve(code)
 
-    res.send(`
+    res.send(
+      options.callbackHtml ??
+        `
       Authorization successful!
       You may close this window and return to the CLI.
       <script>
@@ -639,7 +641,8 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
         // the user will see the message above.
         window.close();
       </script>
-    `)
+    `,
+    )
 
     // Notify main flow that auth code is available
     options.events.emit('auth-code-received', code)
@@ -853,6 +856,23 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     j++
   }
 
+  // Parse callback HTML override
+  // Accepts an inline string or `@/path/to/file.html` to read from disk
+  // (mirrors the convention used by --static-oauth-client-info).
+  let callbackHtml: string | undefined
+  const callbackHtmlIndex = args.indexOf('--callback-html')
+  if (callbackHtmlIndex !== -1 && callbackHtmlIndex < args.length - 1) {
+    const callbackHtmlArg = args[callbackHtmlIndex + 1]
+    if (callbackHtmlArg.startsWith('@')) {
+      const filePath = callbackHtmlArg.slice(1)
+      callbackHtml = await readFile(filePath, 'utf8')
+      log(`Using custom OAuth callback HTML from file: ${filePath}`)
+    } else {
+      callbackHtml = callbackHtmlArg
+      log('Using custom OAuth callback HTML from string')
+    }
+  }
+
   // Parse auth timeout
   let authTimeoutMs = 30000 // Default 30 seconds
   const authTimeoutIndex = args.indexOf('--auth-timeout')
@@ -941,6 +961,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     authorizeResource,
     ignoredTools,
     authTimeoutMs,
+    callbackHtml,
     serverUrlHash,
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,13 +39,14 @@ async function runProxy(
   authorizeResource: string,
   ignoredTools: string[],
   authTimeoutMs: number,
+  callbackHtml: string | undefined,
   serverUrlHash: string,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, callbackHtml)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -179,6 +180,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       authorizeResource,
       ignoredTools,
       authTimeoutMs,
+      callbackHtml,
       serverUrlHash,
     }) => {
       return runProxy(
@@ -192,6 +194,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
         authorizeResource,
         ignoredTools,
         authTimeoutMs,
+        callbackHtml,
         serverUrlHash,
       )
     },


### PR DESCRIPTION
## Summary

Adds a `--callback-html` flag that lets callers override the HTML rendered on the OAuth callback page after a successful code exchange. Default behavior is unchanged when the flag is omitted.

## Motivation

The current callback page reads:

```html
Authorization successful!
You may close this window and return to the CLI.
<script>window.close();</script>
```

That `window.close()` only fires for tabs the script itself opened (via `window.open`). When the host launches the auth tab via the OS-level browser launcher (`xdg-open` on Linux, the `BROWSER` env on macOS, the default-handler shell on Windows), the tab isn't script-closeable — `window.close()` is silently ignored and the user is left looking at unstyled default text.

Hosts that spawn `mcp-remote` programmatically (Claude Desktop, custom IDE integrations, MCP CLIs) often want a quieter or branded landing page. Today the only ways to get it are forking or wrapping `mcp-remote`.

## Design

`--callback-html` accepts either an inline HTML string or a `@`-prefixed filepath, mirroring the convention already used by `--static-oauth-client-info` / `--static-oauth-client-metadata`:

```bash
# Inline (best-effort silent auto-close, no visible text)
npx mcp-remote https://example.remote/server \
  --callback-html '<!doctype html><title>Signed in</title><script>window.close()</script>'

# From a file
npx mcp-remote https://example.remote/server \
  --callback-html '@/Users/me/.config/mcp-remote/callback.html'
```

When the flag is absent the existing default page renders unchanged. The flag is purely cosmetic — the callback handler still receives the auth code and resolves the OAuth flow exactly as before; the supplied HTML is just what the user's browser sees on the loopback page.

## Plumbing

`parseCommandLineArgs` → `proxy.ts` / `client.ts` (`runProxy` / `runClient`) → `createLazyAuthCoordinator` → `coordinateAuth` → `setupOAuthCallbackServerWithLongPoll(options)`. The new option is added to `OAuthCallbackServerOptions` in `types.ts` and applied in `setupOAuthCallbackServerWithLongPoll` via `options.callbackHtml ?? <default>`.

## Tests

5 new tests in `src/lib/utils.test.ts`:

- `setupOAuthCallbackServerWithLongPoll`: default page renders the original "Authorization successful!" text when `callbackHtml` is omitted; supplied HTML renders verbatim when set.
- `parseCommandLineArgs`: `callbackHtml` is `undefined` when the flag is absent; inline string is preserved; `@/path/to/file.html` is read from disk.

All 108 tests pass (5 new + 103 existing); typecheck, prettier, and `tsup` build all clean locally.

## Docs

`README.md` updates:

- New "Custom Callback Page" section under Usage with both inline and `@file` examples.
- Entry added to the existing Flags list pointing at the new section for discoverability.

## Backwards compatibility

Fully additive. No API breakage; the option is optional throughout the plumbing chain.
