### PR TITLE
fix: wait for auth coordination server address

### DIFF
--- a/src/lib/coordination.test.ts
+++ b/src/lib/coordination.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { EventEmitter } from 'events'
+import type { Server } from 'http'
+import type { AddressInfo } from 'net'
+import { waitForListeningAddress } from './coordination'
+
+describe('waitForListeningAddress', () => {
+  it('waits for a server that has not reported its address yet', async () => {
+    const events = new EventEmitter()
+    let address: AddressInfo | null = null
+    const server = {
+      address: () => address,
+      once: (event: string, listener: () => void) => {
+        events.once(event, listener)
+        return server
+      },
+    } as unknown as Server
+
+    const addressPromise = waitForListeningAddress(server)
+    address = { address: '127.0.0.1', family: 'IPv4', port: 4242 }
+    events.emit('listening')
+
+    await expect(addressPromise).resolves.toMatchObject({ port: 4242 })
+  })
+})

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -10,6 +10,20 @@ export type AuthCoordinator = {
   initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }>
 }
 
+export async function waitForListeningAddress(server: Server): Promise<AddressInfo> {
+  let address = server.address()
+  if (!address) {
+    await new Promise<void>((resolve) => server.once('listening', resolve))
+    address = server.address()
+  }
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to get server address after listening event')
+  }
+
+  return address
+}
+
 /**
  * Checks if a process with the given PID is running
  * @param pid The process ID to check
@@ -193,7 +207,7 @@ export async function coordinateAuth(
 
         // Setup a dummy server - the client will use tokens directly from disk
         const dummyServer = express().listen(0) // Listen on any available port
-        const dummyPort = (dummyServer.address() as AddressInfo).port
+        const dummyPort = (await waitForListeningAddress(dummyServer)).port
         debugLog('Started dummy server', { port: dummyPort })
 
         // This shouldn't actually be called in normal operation, but provide it for API compatibility
@@ -235,16 +249,7 @@ export async function coordinateAuth(
   })
 
   // Get the actual port the server is running on
-  let address = server.address() as AddressInfo | null
-  if (!address) {
-    await new Promise<void>((resolve) => server.once('listening', resolve))
-    address = server.address() as AddressInfo | null
-  }
-
-  if (!address) {
-    throw new Error('Failed to get server address after listening event')
-  }
-
+  const address = await waitForListeningAddress(server)
   const actualPort = address.port
   debugLog('OAuth callback server running', { port: actualPort })
 


### PR DESCRIPTION
Fixes #187

Waits for the auth coordination server to report its listening address before reading `address().port`. This covers the shared-auth dummy server path and keeps the primary callback server path using the same helper.

Checks:
- pnpm test:unit
- pnpm build
- pnpm exec tsc
- pnpm exec prettier --check src/lib/coordination.ts src/lib/coordination.test.ts
- git diff --check