### PR TITLE
fix: add params:null normalization, warmup delay, and no-default-scope for Datadog/Zed compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# `mcp-remote`
+# `mcp-remote` (Datadog/Zed fork)
 
-Connect an MCP Client that only supports local (stdio) servers to a Remote MCP Server, with auth support:
+Connect an MCP Client that only supports local (stdio) servers to a Remote MCP Server, with auth support.
+
+> **This is a fork of [geelen/mcp-remote](https://github.com/geelen/mcp-remote) v0.1.38** with additional patches for Datadog and Zed compatibility:
+>
+> - **`params: null` normalization** — Zed sends JSON-RPC notifications with `"params": null`, which the MCP SDK rejects. This fork normalizes them transparently before schema validation.
+> - **Server warmup delay** — Datadog's Streamable HTTP endpoint needs a brief warm-up after the MCP handshake before it can serve `tools/list`. New `--ready-delay-ms` / `--tools-delay-ms` flags let you configure this.
+> - **No-default-scope mode** — mcp-remote v0.1.38 always sends `openid email profile` as a fallback OAuth scope, which causes Datadog to report "MCP CLI Proxy will have no permissions". The `--no-default-scope` flag disables this fallback, restoring the scoping behavior from v0.1.30.
 
 **Note: this is a working proof-of-concept** but should be considered **experimental**.
 
@@ -219,6 +225,40 @@ You can specify multiple `--ignore-tool` flags to ignore different patterns. Exa
       ]
 ```
 
+* *(Datadog/Zed)* To suppress the default `openid email profile` OAuth scope fallback (which can cause Datadog to reject the client), add the `--no-default-scope` flag. Explicitly configured scopes (via `--static-oauth-client-metadata`, WWW-Authenticate header, Protected Resource Metadata, etc.) are still honoured. You can also set the `MCP_REMOTE_NO_DEFAULT_SCOPE=true` environment variable.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--no-default-scope"
+      ]
+```
+
+* *(Datadog/Zed)* To delay all post-`initialize` messages by a fixed number of milliseconds (useful for servers that need time to warm up after the MCP handshake), add the `--ready-delay-ms` flag. The `initialize` message is always sent immediately; all subsequent messages are held until the delay has elapsed. You can also set the `MCP_REMOTE_READY_DELAY_MS` environment variable.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--ready-delay-ms",
+        "2000"
+      ]
+```
+
+* *(Datadog/Zed)* To delay only `tools/list` requests specifically (independent of `--ready-delay-ms`), add the `--tools-delay-ms` flag. You can also set the `MCP_REMOTE_TOOLS_DELAY_MS` environment variable. When both flags are provided, `tools/list` uses `--tools-delay-ms` and all other messages use `--ready-delay-ms`.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--ready-delay-ms",
+        "1000",
+        "--tools-delay-ms",
+        "3000"
+      ]
+```
+
 ### Transport Strategies
 
 MCP Remote supports different transport strategies when connecting to an MCP server. This allows you to control whether it uses Server-Sent Events (SSE) or HTTP transport, and in what order it tries them.
@@ -291,6 +331,35 @@ As of version `0.48.0`, Cursor supports unauthed SSE servers directly. If your M
 ### Windsurf
 
 [Official Docs](https://docs.codeium.com/windsurf/mcp). The configuration file is located at `~/.codeium/windsurf/mcp_config.json`.
+
+### Datadog (via Zed or any stdio-only client)
+
+Datadog's MCP server requires three of the Datadog-specific patches in this fork. A typical configuration looks like:
+
+```json
+{
+  "mcpServers": {
+    "datadog": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://api.datadoghq.com/api/v2/mcp/sse",
+        "--no-default-scope",
+        "--ready-delay-ms",
+        "2000",
+        "--tools-delay-ms",
+        "3000"
+      ]
+    }
+  }
+}
+```
+
+- `--no-default-scope` prevents the generic `openid email profile` scope from being sent, which Datadog interprets as "no permissions".
+- `--ready-delay-ms 2000` gives Datadog's Streamable HTTP endpoint time to initialise before the client sends any further messages.
+- `--tools-delay-ms 3000` waits an additional second before sending `tools/list` so the tool registry is fully ready.
+
+The `params: null` normalization is always active and requires no configuration — it fixes the Zed client sending `"params": null` in JSON-RPC notifications.
 
 ## Building Remote MCP Servers
 

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -302,4 +302,101 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(clientMetadata.scope).toBe('openid email profile')
     })
   })
+
+  describe('noDefaultScope flag (Datadog compatibility)', () => {
+    it('should return undefined scope when noDefaultScope is true and no scope configured', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+      })
+
+      const metadata = provider.clientMetadata
+      // Should not have a scope key at all
+      expect(metadata).not.toHaveProperty('scope')
+    })
+
+    it('should not include scope parameter in authorization URL when noDefaultScope is true', async () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      // Should not have scope param
+      expect(authUrl.searchParams.has('scope')).toBe(false)
+    })
+
+    it('should still honor explicit scope even when noDefaultScope is true', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+        staticOAuthClientMetadata: {
+          scope: 'custom:read custom:write',
+        } as any,
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('custom:read custom:write')
+    })
+
+    it('should still honor WWW-Authenticate scope when noDefaultScope is true', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+        wwwAuthenticateScope: 'mcp:read mcp:write',
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('mcp:read mcp:write')
+    })
+
+    it('should still honor PRM scopes_supported when noDefaultScope is true', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+        protectedResourceMetadata: {
+          resource: 'https://example.com',
+          scopes_supported: ['mcp:read', 'mcp:write'],
+        },
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('mcp:read mcp:write')
+    })
+
+    it('should still honor AS metadata scopes when noDefaultScope is true', () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: ['openid', 'email'],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: true,
+        authorizationServerMetadata: metadata,
+      })
+
+      const clientMetadata = provider.clientMetadata
+      expect(clientMetadata.scope).toBe('openid email')
+    })
+
+    it('should use default scope when noDefaultScope is false (backward compatibility)', () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        noDefaultScope: false,
+      })
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('openid email profile')
+    })
+
+    it('should use default scope when noDefaultScope is not provided (backward compatibility)', () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      const metadata = provider.clientMetadata
+      expect(metadata.scope).toBe('openid email profile')
+    })
+  })
 })

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -34,6 +34,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private authorizationServerMetadata: AuthorizationServerMetadata | undefined
   private protectedResourceMetadata: ProtectedResourceMetadata | undefined
   private wwwAuthenticateScope: string | undefined
+  private noDefaultScope: boolean
 
   /**
    * Creates a new NodeOAuthClientProvider
@@ -54,6 +55,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.authorizationServerMetadata = options.authorizationServerMetadata
     this.protectedResourceMetadata = options.protectedResourceMetadata
     this.wwwAuthenticateScope = options.wwwAuthenticateScope
+    this.noDefaultScope = options.noDefaultScope || false
   }
 
   get redirectUrl(): string {
@@ -62,7 +64,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
   get clientMetadata() {
     const effectiveScope = this.getEffectiveScope()
-    return {
+    const metadata: any = {
       redirect_uris: [this.redirectUrl],
       token_endpoint_auth_method: 'none',
       grant_types: ['authorization_code', 'refresh_token'],
@@ -72,8 +74,14 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       software_id: this.softwareId,
       software_version: this.softwareVersion,
       ...this.staticOAuthClientMetadata,
-      scope: effectiveScope,
     }
+
+    // Only set scope if defined (when noDefaultScope is on, this may be undefined)
+    if (effectiveScope !== undefined) {
+      metadata.scope = effectiveScope
+    }
+
+    return metadata
   }
 
   state(): string {
@@ -106,7 +114,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  private getEffectiveScope(): string {
+  private getEffectiveScope(): string | undefined {
     // Priority 1: User-provided scope from staticOAuthClientMetadata (highest priority)
     if (this.staticOAuthClientMetadata?.scope && this.staticOAuthClientMetadata.scope.trim().length > 0) {
       debugLog('Using scope from staticOAuthClientMetadata', { scope: this.staticOAuthClientMetadata.scope })
@@ -145,7 +153,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       return scope
     }
 
-    // Priority 6: Fallback to hardcoded default
+    // Priority 6: Fallback to hardcoded default (unless noDefaultScope is set)
+    if (this.noDefaultScope) {
+      debugLog('No default scope fallback (noDefaultScope enabled) - returning undefined')
+      return undefined
+    }
+
     debugLog('Using fallback default scope')
     return 'openid email profile'
   }
@@ -263,8 +276,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     const effectiveScope = this.getEffectiveScope()
-    authorizationUrl.searchParams.set('scope', effectiveScope)
-    debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    if (effectiveScope !== undefined) {
+      authorizationUrl.searchParams.set('scope', effectiveScope)
+      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    } else {
+      debugLog('No scope parameter added to authorization URL (undefined)')
+    }
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 

--- a/src/lib/stdio-client-transport.test.ts
+++ b/src/lib/stdio-client-transport.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { createParamsNormalizingStream } from './stdio-client-transport'
+import { Readable } from 'stream'
+
+/**
+ * Tests for the params normalizing stream, which fixes JSON-RPC messages with
+ * `"params": null` before they reach the SDK's schema validation.
+ *
+ * We test the Transform stream directly since it encapsulates the normalization logic
+ * and is simpler to test in isolation than the full transport with process.stdin.
+ */
+describe('createParamsNormalizingStream', () => {
+  async function collectStreamOutput(input: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const normalizingStream = createParamsNormalizingStream()
+      const chunks: Buffer[] = []
+
+      normalizingStream.on('data', (chunk: Buffer) => chunks.push(chunk))
+      normalizingStream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+      normalizingStream.on('error', reject)
+
+      const readable = Readable.from([input])
+      readable.pipe(normalizingStream)
+    })
+  }
+
+  it('should delete params key when params is null', async () => {
+    const input = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: null }) + '\n'
+    const output = await collectStreamOutput(input)
+    const parsed = JSON.parse(output.trim())
+
+    expect(parsed).not.toHaveProperty('params')
+    expect(parsed).toMatchObject({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+  })
+
+  it('should preserve params when it is a valid object', async () => {
+    const input = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'foo', params: { bar: 'baz' } }) + '\n'
+    const output = await collectStreamOutput(input)
+    const parsed = JSON.parse(output.trim())
+
+    expect(parsed).toHaveProperty('params', { bar: 'baz' })
+  })
+
+  it('should pass through messages with no params key', async () => {
+    const input = JSON.stringify({ jsonrpc: '2.0', id: 3, result: { ok: true } }) + '\n'
+    const output = await collectStreamOutput(input)
+    const parsed = JSON.parse(output.trim())
+
+    expect(parsed).not.toHaveProperty('params')
+    expect(parsed).toMatchObject({ result: { ok: true } })
+  })
+
+  it('should handle multiple messages in a single chunk', async () => {
+    const msg1 = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: null })
+    const msg2 = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'pong', params: { data: 'x' } })
+    const input = msg1 + '\n' + msg2 + '\n'
+    const output = await collectStreamOutput(input)
+    const lines = output.trim().split('\n').filter(Boolean)
+
+    expect(lines.length).toBe(2)
+    const parsed1 = JSON.parse(lines[0])
+    const parsed2 = JSON.parse(lines[1])
+
+    expect(parsed1).not.toHaveProperty('params')
+    expect(parsed2).toHaveProperty('params', { data: 'x' })
+  })
+
+  it('should pass through non-JSON lines unchanged', async () => {
+    const input = 'not valid json\n'
+    const output = await collectStreamOutput(input)
+    expect(output.trim()).toBe('not valid json')
+  })
+})

--- a/src/lib/stdio-client-transport.ts
+++ b/src/lib/stdio-client-transport.ts
@@ -1,0 +1,91 @@
+import { Transform } from 'stream'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+
+/**
+ * Creates a Transform stream that normalizes `params: null` to `params` absent
+ * in JSON-RPC messages before they are parsed by the SDK.
+ *
+ * This addresses a compatibility issue where some MCP servers (like Datadog) send
+ * `"params": null` in JSON-RPC messages, which violates the JSONRPCMessage schema
+ * but should be treated as "no params provided".
+ *
+ * The SDK's StdioServerTransport reads from stdin line-by-line and parses each line
+ * through JSONRPCMessageSchema.parse(). By normalizing the input stream before it
+ * reaches the transport, we can fix the schema violation transparently.
+ */
+export function createParamsNormalizingStream(): Transform {
+  let lineBuffer = ''
+
+  return new Transform({
+    transform(chunk: Buffer, _encoding: string, callback: Function) {
+      // Accumulate chunks into lines (JSON-RPC messages are newline-delimited)
+      lineBuffer += chunk.toString('utf8')
+      const lines = lineBuffer.split('\n')
+
+      // Keep the last incomplete line in the buffer
+      lineBuffer = lines.pop() || ''
+
+      // Process complete lines
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            // Parse the JSON-RPC message
+            const message = JSON.parse(line)
+
+            // Normalize params: null -> delete params key
+            if (message && typeof message === 'object' && message.params === null) {
+              delete message.params
+            }
+
+            // Re-serialize and forward with newline
+            this.push(JSON.stringify(message) + '\n')
+          } catch (e) {
+            // If parsing fails (not valid JSON), pass through as-is
+            // The SDK will handle the error appropriately
+            this.push(line + '\n')
+          }
+        } else if (line === '') {
+          // Preserve empty lines
+          this.push('\n')
+        }
+      }
+
+      callback()
+    },
+
+    flush(callback: Function) {
+      // Process any remaining data in the buffer when the stream ends
+      if (lineBuffer.trim()) {
+        try {
+          const message = JSON.parse(lineBuffer)
+          if (message && typeof message === 'object' && message.params === null) {
+            delete message.params
+          }
+          this.push(JSON.stringify(message) + '\n')
+        } catch (e) {
+          // Pass through as-is if not valid JSON
+          this.push(lineBuffer)
+        }
+      }
+      callback()
+    },
+  })
+}
+
+/**
+ * Custom StdioServerTransport that normalizes `params: null` before schema validation.
+ *
+ * The SDK's StdioServerTransport constructor accepts custom stdin/stdout streams.
+ * We exploit this to pipe process.stdin through a normalizing Transform stream
+ * before the SDK reads and parses JSON-RPC messages.
+ */
+export class NormalizingStdioServerTransport extends StdioServerTransport {
+  constructor() {
+    // Create the normalizing stream and pipe process.stdin through it
+    const normalizingStream = createParamsNormalizingStream()
+    process.stdin.pipe(normalizingStream)
+
+    // Pass the normalizing stream as stdin so the SDK reads normalized messages
+    super(normalizingStream, process.stdout)
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface OAuthProviderOptions {
   protectedResourceMetadata?: ProtectedResourceMetadata
   /** Scope extracted from WWW-Authenticate header */
   wwwAuthenticateScope?: string
+  /** Suppress the default 'openid email profile' scope fallback (restores 0.1.30 behavior for Datadog compatibility) */
+  noDefaultScope?: boolean
 }
 
 /**

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1064,3 +1064,190 @@ describe('Feature: Server URL Hash Generation', () => {
     expect(hash1).toBe(hash2)
   })
 })
+
+describe('Feature: Datadog Compatibility Flags', () => {
+  describe('Scenario: Parse --no-default-scope flag', () => {
+    it('should set noDefaultScope to true when flag is present', async () => {
+      const args = ['https://example.com', '--no-default-scope']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.noDefaultScope).toBe(true)
+    })
+
+    it('should set noDefaultScope to false when flag is absent', async () => {
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.noDefaultScope).toBe(false)
+    })
+
+    it('should set noDefaultScope to true from env var', async () => {
+      const original = process.env.MCP_REMOTE_NO_DEFAULT_SCOPE
+      process.env.MCP_REMOTE_NO_DEFAULT_SCOPE = 'true'
+
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.noDefaultScope).toBe(true)
+
+      if (original) process.env.MCP_REMOTE_NO_DEFAULT_SCOPE = original
+      else delete process.env.MCP_REMOTE_NO_DEFAULT_SCOPE
+    })
+  })
+
+  describe('Scenario: Parse --ready-delay-ms flag', () => {
+    it('should set readyDelayMs when flag is present', async () => {
+      const args = ['https://example.com', '--ready-delay-ms', '2000']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.readyDelayMs).toBe(2000)
+    })
+
+    it('should default to 0 when flag is absent', async () => {
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.readyDelayMs).toBe(0)
+    })
+
+    it('should set readyDelayMs from env var', async () => {
+      const original = process.env.MCP_REMOTE_READY_DELAY_MS
+      process.env.MCP_REMOTE_READY_DELAY_MS = '3000'
+
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.readyDelayMs).toBe(3000)
+
+      if (original) process.env.MCP_REMOTE_READY_DELAY_MS = original
+      else delete process.env.MCP_REMOTE_READY_DELAY_MS
+    })
+
+    it('should ignore invalid delay value', async () => {
+      const args = ['https://example.com', '--ready-delay-ms', 'invalid']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.readyDelayMs).toBe(0)
+    })
+  })
+
+  describe('Scenario: Parse --tools-delay-ms flag', () => {
+    it('should set toolsDelayMs when flag is present', async () => {
+      const args = ['https://example.com', '--tools-delay-ms', '2000']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.toolsDelayMs).toBe(2000)
+    })
+
+    it('should default to 0 when flag is absent', async () => {
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.toolsDelayMs).toBe(0)
+    })
+
+    it('should set toolsDelayMs from env var', async () => {
+      const original = process.env.MCP_REMOTE_TOOLS_DELAY_MS
+      process.env.MCP_REMOTE_TOOLS_DELAY_MS = '3000'
+
+      const args = ['https://example.com']
+      const result = await parseCommandLineArgs(args, 'test usage')
+      expect(result.toolsDelayMs).toBe(3000)
+
+      if (original) process.env.MCP_REMOTE_TOOLS_DELAY_MS = original
+      else delete process.env.MCP_REMOTE_TOOLS_DELAY_MS
+    })
+  })
+})
+
+describe('Feature: mcpProxy Warmup Delay', () => {
+  it('should send initialize immediately and delay subsequent messages', async () => {
+    vi.useFakeTimers()
+
+    const sentToServer: any[] = []
+    const mockClientTransport: Transport = {
+      onmessage: undefined,
+      onclose: undefined,
+      onerror: undefined,
+      send: vi.fn(),
+      close: vi.fn(),
+      start: vi.fn(),
+    }
+
+    const mockServerTransport: Transport = {
+      onmessage: undefined,
+      onclose: undefined,
+      onerror: undefined,
+      send: vi.fn((msg) => {
+        sentToServer.push({ message: msg, time: Date.now() })
+        return Promise.resolve()
+      }),
+      close: vi.fn(),
+      start: vi.fn(),
+    }
+
+    // Create proxy with delay
+    mcpProxy({
+      transportToClient: mockClientTransport,
+      transportToServer: mockServerTransport,
+      readyDelayMs: 2000,
+      toolsDelayMs: 2000,
+    })
+
+    const startTime = Date.now()
+
+    // Send initialize - should be immediate
+    mockClientTransport.onmessage?.({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    expect(sentToServer.length).toBe(1)
+    expect(sentToServer[0].message.method).toBe('initialize')
+    expect(sentToServer[0].time).toBe(startTime)
+
+    // Send tools/list - should be delayed by 2000ms
+    mockClientTransport.onmessage?.({ jsonrpc: '2.0', id: 2, method: 'tools/list' })
+    expect(sentToServer.length).toBe(1) // Not sent yet
+
+    // Advance time by 1999ms - still not sent
+    vi.advanceTimersByTime(1999)
+    expect(sentToServer.length).toBe(1)
+
+    // Advance 1 more ms - now it should be sent
+    vi.advanceTimersByTime(1)
+    expect(sentToServer.length).toBe(2)
+    expect(sentToServer[1].message.method).toBe('tools/list')
+    expect(sentToServer[1].time).toBe(startTime + 2000)
+
+    vi.useRealTimers()
+  })
+
+  it('should not delay when delays are 0', async () => {
+    const sentToServer: any[] = []
+    const mockClientTransport: Transport = {
+      onmessage: undefined,
+      onclose: undefined,
+      onerror: undefined,
+      send: vi.fn(),
+      close: vi.fn(),
+      start: vi.fn(),
+    }
+
+    const mockServerTransport: Transport = {
+      onmessage: undefined,
+      onclose: undefined,
+      onerror: undefined,
+      send: vi.fn((msg) => {
+        sentToServer.push(msg)
+        return Promise.resolve()
+      }),
+      close: vi.fn(),
+      start: vi.fn(),
+    }
+
+    // Create proxy with no delay
+    mcpProxy({
+      transportToClient: mockClientTransport,
+      transportToServer: mockServerTransport,
+      readyDelayMs: 0,
+      toolsDelayMs: 0,
+    })
+
+    // Send messages
+    mockClientTransport.onmessage?.({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    mockClientTransport.onmessage?.({ jsonrpc: '2.0', id: 2, method: 'tools/list' })
+
+    // Both should be sent immediately
+    expect(sentToServer.length).toBe(2)
+    expect(sentToServer[0].method).toBe('initialize')
+    expect(sentToServer[1].method).toBe('tools/list')
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -132,13 +132,18 @@ export function mcpProxy({
   transportToClient,
   transportToServer,
   ignoredTools = [],
+  readyDelayMs = 0,
+  toolsDelayMs = 0,
 }: {
   transportToClient: Transport
   transportToServer: Transport
   ignoredTools?: string[]
+  readyDelayMs?: number
+  toolsDelayMs?: number
 }) {
   let transportToClientClosed = false
   let transportToServerClosed = false
+  let initializeTimestamp: number | undefined
 
   const messageTransformer = createMessageTransformer({
     transformRequestFunction: (request: Message) => {
@@ -199,6 +204,37 @@ export function mcpProxy({
       log(JSON.stringify(message, null, 2))
 
       debugLog('Initialize message with modified client info', { clientInfo })
+
+      // Record initialize timestamp for warmup delay
+      if (readyDelayMs > 0 || toolsDelayMs > 0) {
+        initializeTimestamp = Date.now()
+        debugLog('Recorded initialize timestamp for warmup delay', { initializeTimestamp })
+      }
+
+      // Send initialize immediately
+      transportToServer.send(message).catch(onServerError)
+      return
+    }
+
+    // Apply warmup delay for post-initialize messages if configured
+    if (initializeTimestamp !== undefined && (readyDelayMs > 0 || toolsDelayMs > 0)) {
+      const delayMs = message.method === 'tools/list' ? toolsDelayMs : readyDelayMs
+      if (delayMs > 0) {
+        const elapsed = Date.now() - initializeTimestamp
+        const remainingDelay = Math.max(0, delayMs - elapsed)
+
+        if (remainingDelay > 0) {
+          debugLog(`Delaying ${message.method || message.id} by ${remainingDelay}ms for server warmup`, {
+            delayMs,
+            elapsed,
+            remainingDelay,
+          })
+          setTimeout(() => {
+            transportToServer.send(message).catch(onServerError)
+          }, remainingDelay)
+          return
+        }
+      }
     }
 
     transportToServer.send(message).catch(onServerError)
@@ -929,6 +965,50 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     })
   }
 
+  // Parse --no-default-scope flag (for Datadog compatibility)
+  const noDefaultScope = args.includes('--no-default-scope') || process.env.MCP_REMOTE_NO_DEFAULT_SCOPE === 'true'
+  if (noDefaultScope) {
+    log('No-default-scope mode enabled - will not send generic OIDC scope fallback')
+  }
+
+  // Parse --ready-delay-ms flag (for Datadog warmup)
+  let readyDelayMs = 0
+  const readyDelayIndex = args.indexOf('--ready-delay-ms')
+  if (readyDelayIndex !== -1 && readyDelayIndex < args.length - 1) {
+    const delayValue = parseInt(args[readyDelayIndex + 1], 10)
+    if (!isNaN(delayValue) && delayValue >= 0) {
+      readyDelayMs = delayValue
+      log(`Using ready delay: ${readyDelayMs}ms`)
+    } else {
+      log(`Warning: Ignoring invalid ready-delay-ms value: ${args[readyDelayIndex + 1]}. Must be a non-negative number.`)
+    }
+  } else if (process.env.MCP_REMOTE_READY_DELAY_MS) {
+    const envValue = parseInt(process.env.MCP_REMOTE_READY_DELAY_MS, 10)
+    if (!isNaN(envValue) && envValue >= 0) {
+      readyDelayMs = envValue
+      log(`Using ready delay from env: ${readyDelayMs}ms`)
+    }
+  }
+
+  // Parse --tools-delay-ms flag (for Datadog tools/list warmup)
+  let toolsDelayMs = 0
+  const toolsDelayIndex = args.indexOf('--tools-delay-ms')
+  if (toolsDelayIndex !== -1 && toolsDelayIndex < args.length - 1) {
+    const delayValue = parseInt(args[toolsDelayIndex + 1], 10)
+    if (!isNaN(delayValue) && delayValue >= 0) {
+      toolsDelayMs = delayValue
+      log(`Using tools/list delay: ${toolsDelayMs}ms`)
+    } else {
+      log(`Warning: Ignoring invalid tools-delay-ms value: ${args[toolsDelayIndex + 1]}. Must be a non-negative number.`)
+    }
+  } else if (process.env.MCP_REMOTE_TOOLS_DELAY_MS) {
+    const envValue = parseInt(process.env.MCP_REMOTE_TOOLS_DELAY_MS, 10)
+    if (!isNaN(envValue) && envValue >= 0) {
+      toolsDelayMs = envValue
+      log(`Using tools/list delay from env: ${toolsDelayMs}ms`)
+    }
+  }
+
   return {
     serverUrl,
     callbackPort,
@@ -942,6 +1022,9 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     ignoredTools,
     authTimeoutMs,
     serverUrlHash,
+    noDefaultScope,
+    readyDelayMs,
+    toolsDelayMs,
   }
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,7 @@
  */
 
 import { EventEmitter } from 'events'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { NormalizingStdioServerTransport } from './lib/stdio-client-transport'
 import {
   connectToRemoteServer,
   log,
@@ -40,6 +40,9 @@ async function runProxy(
   ignoredTools: string[],
   authTimeoutMs: number,
   serverUrlHash: string,
+  noDefaultScope?: boolean,
+  readyDelayMs?: number,
+  toolsDelayMs?: number,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
@@ -76,10 +79,11 @@ async function runProxy(
     authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
     protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
     wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
+    noDefaultScope,
   })
 
-  // Create the STDIO transport for local connections
-  const localTransport = new StdioServerTransport()
+  // Create the STDIO transport for local connections with params:null normalization
+  const localTransport = new NormalizingStdioServerTransport()
 
   // Keep track of the server instance for cleanup
   let server: any = null
@@ -114,6 +118,8 @@ async function runProxy(
       transportToClient: localTransport,
       transportToServer: remoteTransport,
       ignoredTools,
+      readyDelayMs,
+      toolsDelayMs,
     })
 
     // Start the local STDIO server
@@ -180,6 +186,9 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       ignoredTools,
       authTimeoutMs,
       serverUrlHash,
+      noDefaultScope,
+      readyDelayMs,
+      toolsDelayMs,
     }) => {
       return runProxy(
         serverUrl,
@@ -193,6 +202,9 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
         ignoredTools,
         authTimeoutMs,
         serverUrlHash,
+        noDefaultScope,
+        readyDelayMs,
+        toolsDelayMs,
       )
     },
   )


### PR DESCRIPTION
Three patches to make mcp-remote work correctly with Datadog's MCP server when used from a Zed extension (or any stdio-only client):

- params:null normalization (P1): Zed sends JSON-RPC notifications with `"params": null`, which the MCP SDK's JSONRPCMessageSchema rejects. Introduced NormalizingStdioServerTransport (src/lib/stdio-client-transport.ts) that pipes process.stdin through a Transform stream stripping `params: null` before schema validation. proxy.ts now uses this instead of StdioServerTransport.

- Server warmup delay (P2): Datadog's Streamable HTTP endpoint needs time to initialise after the MCP handshake. mcpProxy now accepts readyDelayMs and toolsDelayMs options. The `initialize` message is always forwarded immediately; subsequent messages are held until the configured window elapses (tools/list uses toolsDelayMs, all others use readyDelayMs). Configurable via: --ready-delay-ms <ms>  / MCP_REMOTE_READY_DELAY_MS=<ms> --tools-delay-ms <ms>  / MCP_REMOTE_TOOLS_DELAY_MS=<ms>

- No-default-scope (P3): mcp-remote v0.1.38 always falls back to sending `openid email profile` as OAuth scope, which Datadog interprets as "MCP CLI Proxy will have no permissions". The --no-default-scope flag (or MCP_REMOTE_NO_DEFAULT_SCOPE=true) suppresses only this priority-6 fallback; explicit scopes from staticOAuthClientMetadata, WWW-Authenticate, PRM, client registration, or AS metadata (priorities 1-5) are unaffected.

Unit tests added for all three fixes (128 tests, 5 files, all passing). README updated with fork notice, new flag documentation, and a Datadog example configuration.