### PR TITLE
fix: add Accept-Encoding: identity to OAuth discovery fetch requests

### DIFF
--- a/src/lib/authorization-server-metadata.ts
+++ b/src/lib/authorization-server-metadata.ts
@@ -52,6 +52,7 @@ export async function fetchAuthorizationServerMetadata(serverUrl: string): Promi
     const response = await fetch(metadataUrl, {
       headers: {
         Accept: 'application/json',
+        'Accept-Encoding': 'identity',
       },
       // Short timeout to avoid blocking
       signal: AbortSignal.timeout(5000),

--- a/src/lib/protected-resource-metadata.ts
+++ b/src/lib/protected-resource-metadata.ts
@@ -133,6 +133,7 @@ async function fetchProtectedResourceMetadataFromUrl(metadataUrl: string): Promi
     const response = await fetch(metadataUrl, {
       headers: {
         Accept: 'application/json',
+        'Accept-Encoding': 'identity',
       },
       signal: AbortSignal.timeout(5000),
     })


### PR DESCRIPTION
## Summary

Node's built-in `fetch` (undici) sends `Accept-Encoding: gzip, deflate, br` by default on every request. Servers that honor this header -- including `mcp.atlassian.com` -- return gzip-compressed response bodies. `fetchAuthorizationServerMetadata` and `fetchProtectedResourceMetadata` both call `response.json()` on the raw compressed bytes, causing a fatal crash before any OAuth flow begins:

```
Connection error: SyntaxError: Unexpected token '', "..."  is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:4227:19)
```

The `--header` CLI arg does not help here because custom headers are only applied to MCP transport requests, not to the upstream OAuth discovery fetches.

## Changes

- `src/lib/authorization-server-metadata.ts`: add `Accept-Encoding: identity` to the discovery fetch
- `src/lib/protected-resource-metadata.ts`: same fix for consistency

## Test plan

- [ ] `mcp-remote https://mcp.atlassian.com/v1/mcp --resource https://<org>.atlassian.net/` proceeds past OAuth discovery on Node 18+
- [ ] Existing tests pass

Fixes #276
