### PR TITLE
fix: omit scope when server declares empty scopes_supported

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -301,5 +301,37 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       // Empty scope should fallback to default
       expect(clientMetadata.scope).toBe('openid email profile')
     })
+
+    it('should omit scope from clientMetadata when server declares empty scopes_supported and no other scopes provided', () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      const clientMetadata = provider.clientMetadata
+      expect(clientMetadata.scope).toBeUndefined()
+    })
+
+    it('should omit scope from authorization URL when server declares empty scopes_supported and no other scopes provided', async () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.has('scope')).toBe(false)
+    })
   })
 })

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -72,7 +72,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       software_id: this.softwareId,
       software_version: this.softwareVersion,
       ...this.staticOAuthClientMetadata,
-      scope: effectiveScope,
+      ...(effectiveScope && { scope: effectiveScope }),
     }
   }
 
@@ -145,7 +145,13 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       return scope
     }
 
-    // Priority 6: Fallback to hardcoded default
+    // Priority 6: If the server explicitly declares scopes_supported (even empty), respect it
+    if (Array.isArray(this.authorizationServerMetadata?.scopes_supported)) {
+      debugLog('Server declares empty scopes_supported, using no scope')
+      return ''
+    }
+
+    // Priority 7: Fallback to hardcoded default
     debugLog('Using fallback default scope')
     return 'openid email profile'
   }
@@ -263,8 +269,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     const effectiveScope = this.getEffectiveScope()
-    authorizationUrl.searchParams.set('scope', effectiveScope)
-    debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    if (effectiveScope) {
+      authorizationUrl.searchParams.set('scope', effectiveScope)
+      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    }
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 


### PR DESCRIPTION
The server's scopes_supported: [] is now treated as an explicit signal to send no scope — previously it would fall through to the hardcoded openid email profile default. Scope is omitted from both clientMetadata and the authorization URL redirect.

This is needed for mcp-remote to work with some MCP which expect no scopes in this case, such as DataDog's.