### PR TITLE
docs: add Xquik API-key example and redact header logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ To bypass authentication, or to emit custom headers on all requests to your remo
 },
 ```
 
+For Xquik's Streamable HTTP server, set the API key in `env` and force HTTP transport:
+
+```json
+{
+  "mcpServers": {
+    "xquik": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://xquik.com/mcp",
+        "--transport",
+        "http-only",
+        "--header",
+        "x-api-key:${XQUIK_API_KEY}"
+      ],
+      "env": {
+        "XQUIK_API_KEY": "<xquik-api-key>"
+      }
+    }
+  }
+}
+```
+
 ### Multiple Instances
 
 To run multiple instances of the same remote server with different configurations (e.g., different Atlassian tenants), use the `--resource` flag to isolate OAuth sessions:

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -70,6 +70,19 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(result.headers).toEqual({ foo: 'taz' })
   })
 
+  it('Scenario: Do not log custom header values', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const args = ['https://example.com/sse', '--header', 'Authorization: Bearer private-token']
+
+    const result = await parseCommandLineArgs(args, 'test usage')
+
+    expect(result.headers).toEqual({ Authorization: 'Bearer private-token' })
+    expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain('private-token')
+    expect(JSON.stringify(consoleSpy.mock.calls)).toContain('Authorization')
+
+    consoleSpy.mockRestore()
+  })
+
   it('Scenario: Parse multiple custom headers', async () => {
     // Given command line arguments with multiple custom headers
     const args = ['https://example.com/sse', '--header', 'Authorization: Bearer token123', '--header', 'Content-Type: application/json']

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -911,7 +911,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   }
 
   if (Object.keys(headers).length > 0) {
-    log(`Using custom headers: ${JSON.stringify(headers)}`)
+    log(`Using custom header names: ${Object.keys(headers).join(', ')}`)
   }
   // Replace environment variables in headers
   // example `Authorization: Bearer ${TOKEN}` will read process.env.TOKEN


### PR DESCRIPTION
## What changed

- Added a Streamable HTTP Xquik example using the correct x-api-key header.
- Keeps the raw key in an environment variable and forces HTTP-only transport.
- Fixed existing custom-header logging so secret header values are never printed or written to debug logs.
- Added a regression test proving header values remain absent from logs.

## Validation

- 104 unit tests passed.
- Prettier and TypeScript checks passed.
- Production build passed.
- Diff checks passed.

The header log redaction is independent of the Xquik example and protects every custom-header user.